### PR TITLE
Docker deployment: Optionally avoid container deletion

### DIFF
--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -39,6 +39,8 @@ class DockerDeploymentConfig(BaseModel):
     """The directory to use for the python standalone."""
     platform: str | None = None
     """The platform to use for the docker image."""
+    remove_container: bool = True
+    """Whether to remove the container after it has stopped."""
 
     type: Literal["docker"] = "docker"
     """Discriminator for (de)serialization/CLI. Do not change."""

--- a/src/swerex/deployment/docker.py
+++ b/src/swerex/deployment/docker.py
@@ -238,10 +238,13 @@ class DockerDeployment(AbstractDeployment):
         platform_arg = []
         if self._config.platform is not None:
             platform_arg = ["--platform", self._config.platform]
+        rm_arg = []
+        if self._config.remove_container:
+            rm_arg = ["--rm"]
         cmds = [
             "docker",
             "run",
-            "--rm",
+            *rm_arg,
             "-p",
             f"{self._config.port}:8000",
             *platform_arg,


### PR DESCRIPTION
It's sometimes useful to look at the state of a container after the agent workflow completed, e.g. when the agent made changes outside the repository. This PR introduces a new configuration option which controls whether the container should be cleaned up automatically. 

The default value matches the current behavior of always automatically deleting the container.