### PR TITLE
Use Modal async Sandbox APIs

### DIFF
--- a/tests/test_modal_deployment.py
+++ b/tests/test_modal_deployment.py
@@ -10,7 +10,7 @@ from swerex.deployment.modal import ModalDeployment, _ImageBuilder
 async def test_modal_deployment_from_docker_with_swerex_installed():
     dockerfile = Path(__file__).parent / "swe_rex_test.Dockerfile"
     image = _ImageBuilder().from_file(dockerfile, build_context=Path(__file__).resolve().parent.parent)
-    d = ModalDeployment(image=image, startup_timeout=60)
+    d = ModalDeployment(image=image, startup_timeout=60 * 5)
     with pytest.raises(RuntimeError):
         await d.is_alive()
     await d.start()


### PR DESCRIPTION
The existing Modal deployment uses the blocking version of Modal Sandbox APIs from within async functions which interferes with the asyncio event loop. 

This changes the Modal deployment to use the async versions of these functions.

The only breaking API change is making the `get_modal_log_url` function `async`. This isn't called from anywhere in the rest of the SWE-ReX repo right now.

I also increased the startup timeout on the Modal test that deploys from the Dockerfile since that one was failing due to a timeout. (Building the image takes a while - comfortably less than 5 minutes though.)

I tested this with the following commands, and the tests passed:
```sh
$ pip install .
$ pytest -k modal
```

I also ran a test that uses SWE-ReX with Modal from concurrent tasks using this version and could see that sandbox creation was happening concurrently as expected (rather than sequentially, as it works currently).
