### PR TITLE
Fix/strip only cr in session

### DIFF
--- a/src/swerex/runtime/local.py
+++ b/src/swerex/runtime/local.py
@@ -93,7 +93,7 @@ def _split_bash_command(inpt: str) -> list[str]:
 
 def _strip_control_chars(s: str) -> str:
     ansi_escape = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
-    return ansi_escape.sub("", s).replace("\r\n", "\n").replace("\r", "")
+    return ansi_escape.sub("", s).replace("\r\n", "\n")
 
 
 def _check_bash_command(command: str) -> None:

--- a/src/swerex/runtime/local.py
+++ b/src/swerex/runtime/local.py
@@ -297,7 +297,7 @@ class BashSession(Session):
             # Bashlex is very buggy and can throw a variety of errors, including
             # ParsingErrors, NotImplementedErrors, TypeErrors, possibly more. So we catch them all
             self.logger.error("Bashlex fail: %s", e)
-            action.command += f"\n TMPEXITCODE=$? ; sleep 0.1; echo '{self._UNIQUE_STRING}' ; (exit $TMPEXITCODE)"
+            action.command += f"\n TMPEXITCODE=$? ; sleep 0.1; echo -n '{self._UNIQUE_STRING}' ; (exit $TMPEXITCODE)"
             fallback_terminator = True
         else:
             action.command = " ; ".join(individual_commands)

--- a/src/swerex/runtime/local.py
+++ b/src/swerex/runtime/local.py
@@ -93,7 +93,7 @@ def _split_bash_command(inpt: str) -> list[str]:
 
 def _strip_control_chars(s: str) -> str:
     ansi_escape = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
-    return ansi_escape.sub("", s).replace("\r\n", "\n")
+    return ansi_escape.sub("", s).replace("\r\n", "\n").replace("\r", "")
 
 
 def _check_bash_command(command: str) -> None:

--- a/src/swerex/runtime/local.py
+++ b/src/swerex/runtime/local.py
@@ -93,7 +93,7 @@ def _split_bash_command(inpt: str) -> list[str]:
 
 def _strip_control_chars(s: str) -> str:
     ansi_escape = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
-    return ansi_escape.sub("", s)
+    return ansi_escape.sub("", s).replace("\r\n", "\n")
 
 
 def _check_bash_command(command: str) -> None:
@@ -253,7 +253,7 @@ class BashSession(Session):
         except pexpect.TIMEOUT as e:
             msg = f"timeout after {action.timeout} seconds while running command {action.command!r}"
             raise CommandTimeoutError(msg) from e
-        output: str = _strip_control_chars(self.shell.before).strip()  # type: ignore
+        output: str = _strip_control_chars(self.shell.before)  # type: ignore
         if action.is_interactive_quit:
             assert not action.is_interactive_command
             self.shell.setecho(False)
@@ -312,7 +312,7 @@ class BashSession(Session):
         except pexpect.TIMEOUT as e:
             msg = f"timeout after {action.timeout} seconds while running command {action.command!r}"
             raise CommandTimeoutError(msg) from e
-        output: str = _strip_control_chars(self.shell.before).strip()  # type: ignore
+        output: str = _strip_control_chars(self.shell.before)  # type: ignore
 
         # Part 3: Get the exit code
         if action.check == "ignore":
@@ -327,7 +327,7 @@ class BashSession(Session):
             except pexpect.TIMEOUT:
                 msg = "timeout while getting exit code"
                 raise NoExitCodeError(msg)
-            exit_code_raw: str = _strip_control_chars(self.shell.before).strip()  # type: ignore
+            exit_code_raw: str = _strip_control_chars(self.shell.before)  # type: ignore
             exit_code = re.findall(f"{_exit_code_prefix}([0-9]+)", exit_code_raw)
             if len(exit_code) != 1:
                 msg = f"failed to parse exit code from output {exit_code_raw!r} (command: {action.command!r}, matches: {exit_code})"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -48,6 +48,22 @@ async def test_execute_command(remote_runtime: RemoteRuntime):
     assert (await remote_runtime.execute(C(command="echo 'hello world'", shell=True))).stdout == "hello world\n"
 
 
+async def test_execute_command_with_empty_string(remote_runtime: RemoteRuntime):
+    assert (await remote_runtime.execute(C(command="echo ''", shell=True))).stdout == "\n"
+
+
+async def test_execute_command_with_empty_string_in_session(runtime_with_default_session: RemoteRuntime):
+    assert (await runtime_with_default_session.run_in_session(A(command="echo ''", check="raise"))).output == "\n"
+
+
+async def test_execute_command_with_leading_space_output(remote_runtime: RemoteRuntime):
+    assert (await remote_runtime.execute(C(command="echo '\n \nhello world'", shell=True))).stdout == "\n \nhello world\n"
+
+
+async def test_execute_command_with_leading_space_in_session(runtime_with_default_session: RemoteRuntime):
+    assert (await runtime_with_default_session.run_in_session(A(command="echo '\n \nhello\nworld'", check="raise"))).output == "\n \nhello\nworld\n"
+
+
 async def test_execute_command_shell_false(remote_runtime: RemoteRuntime):
     assert (await remote_runtime.execute(C(command=["echo", "hello world"], shell=False))).stdout == "hello world\n"
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -57,19 +57,25 @@ async def test_execute_command_with_empty_string_in_session(runtime_with_default
 
 
 async def test_execute_command_with_leading_space_output(remote_runtime: RemoteRuntime):
-    assert (await remote_runtime.execute(C(command="echo '\n \nhello world'", shell=True))).stdout == "\n \nhello world\n"
+    assert (
+        await remote_runtime.execute(C(command="echo '\n \nhello world'", shell=True))
+    ).stdout == "\n \nhello world\n"
+
 
 async def test_execute_command_with_echon(remote_runtime: RemoteRuntime):
     assert (await remote_runtime.execute(C(command="echo -n 'hello world'", shell=True))).stdout == "hello world"
     assert (await remote_runtime.execute(C(command="echo -n 'hello world\n'", shell=True))).stdout == "hello world\n"
     assert (await remote_runtime.execute(C(command="echo -n '\nhello world'", shell=True))).stdout == "\nhello world"
 
+
 async def test_execute_command_with_newline_in_session(runtime_with_default_session: RemoteRuntime):
     assert (await runtime_with_default_session.run_in_session(A(command="printf '\nx'", check="raise"))).output == "\nx"
 
 
 async def test_execute_command_with_many_newlines_in_session(runtime_with_default_session: RemoteRuntime):
-    assert (await runtime_with_default_session.run_in_session(A(command="printf '\n\nx\n\n\n'", check="raise"))).output == "\n\nx\n\n\n"
+    assert (
+        await runtime_with_default_session.run_in_session(A(command="printf '\n\nx\n\n\n'", check="raise"))
+    ).output == "\n\nx\n\n\n"
 
 
 async def test_execute_command_with_whitespace_in_session(runtime_with_default_session: RemoteRuntime):
@@ -77,7 +83,9 @@ async def test_execute_command_with_whitespace_in_session(runtime_with_default_s
 
 
 async def test_execute_command_with_leading_space_in_session(runtime_with_default_session: RemoteRuntime):
-    assert (await runtime_with_default_session.run_in_session(A(command="echo '\n \nhello\nworld'", check="raise"))).output == "\n \nhello\nworld\n"
+    assert (
+        await runtime_with_default_session.run_in_session(A(command="echo '\n \nhello\nworld'", check="raise"))
+    ).output == "\n \nhello\nworld\n"
 
 
 async def test_execute_command_shell_false(remote_runtime: RemoteRuntime):


### PR DESCRIPTION
- This PR updates the command input and output processing
- Remove windows-style "crlf" line endings from pexpect outputs
- Remove extra endline from echo in `local.BashSession._run_normal`'s fallback UNIQUE_STRING based output parsing
- Updates tests related to execution / testing output to be even stricter

This update makes outputs more reliable, consistent, and true to standard unix shells' expected output. For instance, outputs of `echo` commands will include a training newline, which was being stripped before.