### PR TITLE
fix: make the env var of the child shell consistent with parent shell

### DIFF
--- a/src/swerex/runtime/local.py
+++ b/src/swerex/runtime/local.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import re
 import shutil
@@ -159,7 +160,7 @@ class BashSession(Session):
             encoding="utf-8",
             codec_errors="backslashreplace",
             echo=False,
-            env={"PS1": self._ps1, "PS2": "", "PS0": ""},  # type: ignore
+            env=dict(os.environ.copy(), **{"PS1": self._ps1, "PS2": "", "PS0": ""}) # type: ignore
         )
         time.sleep(0.3)
         cmds = []

--- a/src/swerex/runtime/local.py
+++ b/src/swerex/runtime/local.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -160,7 +160,7 @@ class BashSession(Session):
             encoding="utf-8",
             codec_errors="backslashreplace",
             echo=False,
-            env=dict(os.environ.copy(), **{"PS1": self._ps1, "PS2": "", "PS0": ""}) # type: ignore
+            env=dict(os.environ.copy(), **{"PS1": self._ps1, "PS2": "", "PS0": ""}),  # type: ignore
         )
         time.sleep(0.3)
         cmds = []


### PR DESCRIPTION
I also encountered the issue where the shell's PATH environment variable did not inherit the container's PATH environment variable and make some changes to fix the issue.

Closes #185 