### PR TITLE
Increase Timeouts and Fix Modal Deployment Bug

### DIFF
--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -95,7 +95,7 @@ class ModalDeploymentConfig(BaseModel):
     """Runtime timeout (default timeout for all runtime requests)
     """
 
-    deployment_timeout: float = 1800.0
+    deployment_timeout: float = 3600.0
     """Kill deployment after this many seconds no matter what.
     This is a useful killing switch to ensure that you don't spend too 
     much money on modal.

--- a/src/swerex/deployment/modal.py
+++ b/src/swerex/deployment/modal.py
@@ -117,10 +117,10 @@ class ModalDeployment(AbstractDeployment):
         logger: logging.Logger | None = None,
         image: str | modal.Image | PurePath,
         startup_timeout: float = 0.4,
-        runtime_timeout: float = 1800.0,
+        runtime_timeout: float = 3600.0,
         modal_sandbox_kwargs: dict[str, Any] | None = None,
         install_pipx: bool = True,
-        deployment_timeout: float = 1800.0,
+        deployment_timeout: float = 3600.0,
     ):
         """Deployment for modal.com. The deployment will only start when the
         `start` method is being called.
@@ -209,6 +209,10 @@ class ModalDeployment(AbstractDeployment):
         self,
     ):
         """Starts the runtime."""
+        if self._runtime is not None and self._sandbox is not None:
+            self.logger.warning("Deployment is already started. Ignoring duplicate start() call.")
+            return
+
         self.logger.info("Starting modal sandbox")
         self._hooks.on_custom_step("Starting modal sandbox")
         t0 = time.time()


### PR DESCRIPTION
This PR includes the two following changes:

### Increased timeouts x2 from `1800` to `3600` (30 min to 1 hr)
This is based on our observation that users often hit the initial 30 minute timeouts and have to manually adjust.

### ModalDeployment Initialization Bug
When a deployment is already started, warn on calling `deployment.start()` twice to prevent orphaned deployment with no cleanup.
  - An alternate design is to warn, clean up old deployment, and start new one, but my understanding is that it is not intended behavior and duplicate calls are only done in error (when copying code blocks).
