### PR TITLE
Add a merge_output_streams option for Command

### DIFF
--- a/src/swerex/runtime/abstract.py
+++ b/src/swerex/runtime/abstract.py
@@ -171,6 +171,10 @@ class Command(BaseModel):
     cwd: str | None = None
     """The current working directory to run the command in."""
 
+    merge_output_streams: bool = False
+    """If True, combine stdout and stderr into a single stream.
+    """
+
 
 class CommandResponse(BaseModel):
     stdout: str = ""

--- a/src/swerex/runtime/dummy.py
+++ b/src/swerex/runtime/dummy.py
@@ -79,7 +79,7 @@ class DummyRuntime(AbstractRuntime):
         raise ValueError(msg)
 
     async def execute(self, command: Command) -> CommandResponse:
-        return CommandResponse(exit_code=0)
+        return CommandResponse(stdout="", stderr="", exit_code=0)
 
     async def read_file(self, request: ReadFileRequest) -> ReadFileResponse:
         return ReadFileResponse()

--- a/src/swerex/runtime/local.py
+++ b/src/swerex/runtime/local.py
@@ -428,12 +428,13 @@ class LocalRuntime(AbstractRuntime):
                 shell=command.shell,
                 timeout=command.timeout,
                 env=command.env,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT if command.merge_output_streams else subprocess.PIPE,
                 cwd=command.cwd,
             )
             r = CommandResponse(
                 stdout=result.stdout.decode(errors="backslashreplace"),
-                stderr=result.stderr.decode(errors="backslashreplace"),
+                stderr=result.stderr.decode(errors="backslashreplace") if result.stderr is not None else "",
                 exit_code=result.returncode,
             )
         except subprocess.TimeoutExpired as e:

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -223,6 +223,18 @@ async def test_empty_command(remote_runtime: RemoteRuntime):
     await remote_runtime.execute(C(command="\n", shell=True, check=True))
 
 
+async def test_execute_merge_output_streams_true(remote_runtime: RemoteRuntime):
+    r = await remote_runtime.execute(C(command=["bash", "-lc", "echo 'out'; echo 'err' 1>&2"], shell=False, merge_output_streams=True))
+    assert r.stderr == ""
+    assert r.stdout.splitlines() == ["out", "err"]
+
+
+async def test_execute_merge_output_streams_false(remote_runtime: RemoteRuntime):
+    r = await remote_runtime.execute(C(command=["bash", "-lc", "echo out; echo err 1>&2"], shell=False, merge_output_streams=False))
+    assert r.stdout.strip() == "out"
+    assert r.stderr.strip() == "err"
+
+
 async def test_command_fails_check_exit_code(runtime_with_default_session: RemoteRuntime):
     with pytest.raises(NonZeroExitCodeError):
         await runtime_with_default_session.run_in_session(A(command="false", check="raise"))


### PR DESCRIPTION
This change allows users to set "merge_output_streams=True" when invoking a command. This sets `stderr` to `subprocessing.STDOUT` when True, which is useful for multiplexing command outputs as they would be seen in a regular terminal.