### PR TITLE
feat: use pre-built swerex-remote in containers

### DIFF
--- a/.github/workflows/release_swerex_remote.yaml
+++ b/.github/workflows/release_swerex_remote.yaml
@@ -24,6 +24,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -65,14 +68,7 @@ jobs:
         # Create output directory
         mkdir -p output
         
-        # Use different base images for different architectures to maximize compatibility
-        if [ "${{ matrix.arch }}" = "amd64" ]; then
-          # Use Ubuntu 14.04 for AMD64 (maximum compatibility with old systems)
-          BASE_IMAGE="ubuntu:14.04"
-        else
-          # Use Ubuntu 16.04 for ARM64 (first Ubuntu with official ARM64 support)
-          BASE_IMAGE="ubuntu:16.04"
-        fi
+        BASE_IMAGE="ubuntu:14.04"
         
         docker run --rm \
           --platform linux/${{ matrix.arch }} \

--- a/.github/workflows/release_swerex_remote.yaml
+++ b/.github/workflows/release_swerex_remote.yaml
@@ -14,7 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [x86_64, aarch64]
+        include:
+          - arch: amd64
+            name: amd64
+          - arch: arm64
+            name: aarch64
     
     steps:
     - name: Checkout code
@@ -23,7 +27,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Build executable in Ubuntu 14.04 container
+    - name: Build executable in compatible container
       run: |
         # Create build script
         cat > build_script.sh << 'EOF'
@@ -49,11 +53,11 @@ jobs:
         uv pip install pyinstaller
         
         # Build executable
-        pyinstaller src/swerex/server.py --onefile --name swerex-remote-$ARCH
+        pyinstaller src/swerex/server.py --onefile --name swerex-remote-$ARCH_NAME
         
         # Make executable and copy to output
-        chmod +x dist/swerex-remote-$ARCH
-        cp dist/swerex-remote-$ARCH /output/
+        chmod +x dist/swerex-remote-$ARCH_NAME
+        cp dist/swerex-remote-$ARCH_NAME /output/
         EOF
         
         chmod +x build_script.sh
@@ -61,21 +65,29 @@ jobs:
         # Create output directory
         mkdir -p output
         
-        # Build using Ubuntu 14.04 with emulation for cross-platform builds
+        # Use different base images for different architectures to maximize compatibility
+        if [ "${{ matrix.arch }}" = "amd64" ]; then
+          # Use Ubuntu 14.04 for AMD64 (maximum compatibility with old systems)
+          BASE_IMAGE="ubuntu:14.04"
+        else
+          # Use Ubuntu 16.04 for ARM64 (first Ubuntu with official ARM64 support)
+          BASE_IMAGE="ubuntu:16.04"
+        fi
+        
         docker run --rm \
-          --platform linux/${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64' }} \
+          --platform linux/${{ matrix.arch }} \
           -v $(pwd):/workspace \
           -v $(pwd)/output:/output \
           -w /workspace \
-          -e ARCH=${{ matrix.arch }} \
-          ubuntu:14.04 \
+          -e ARCH_NAME=${{ matrix.name }} \
+          $BASE_IMAGE \
           bash build_script.sh
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: swerex-remote-${{ matrix.arch }}
-        path: output/swerex-remote-${{ matrix.arch }}
+        name: swerex-remote-${{ matrix.name }}
+        path: output/swerex-remote-${{ matrix.name }}
         retention-days: 30
 
   release:
@@ -95,7 +107,7 @@ jobs:
     - name: Prepare release assets
       run: |
         mkdir -p release_assets
-        cp artifacts/swerex-remote-x86_64/swerex-remote-x86_64 release_assets/
+        cp artifacts/swerex-remote-amd64/swerex-remote-amd64 release_assets/
         cp artifacts/swerex-remote-aarch64/swerex-remote-aarch64 release_assets/
         
         # Create checksums
@@ -134,15 +146,15 @@ jobs:
           ${{ steps.release_info.outputs.body }}
           
           ## Download Links
-          - **Linux x86_64**: [swerex-remote-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.tag }}/swerex-remote-x86_64)
+          - **Linux AMD64**: [swerex-remote-amd64](https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.tag }}/swerex-remote-amd64)
           - **Linux ARM64**: [swerex-remote-aarch64](https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.tag }}/swerex-remote-aarch64)
           - **Checksums**: [checksums.txt](https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.tag }}/checksums.txt)
           
           ${{ steps.release_info.outputs.type == 'version' && '## Always Latest Links
-          - **Linux x86_64**: [swerex-remote-x86_64](https://github.com/' || '' }}${{ steps.release_info.outputs.type == 'version' && github.repository || '' }}${{ steps.release_info.outputs.type == 'version' && '/releases/latest/download/swerex-remote-x86_64)
+          - **Linux AMD64**: [swerex-remote-amd64](https://github.com/' || '' }}${{ steps.release_info.outputs.type == 'version' && github.repository || '' }}${{ steps.release_info.outputs.type == 'version' && '/releases/latest/download/swerex-remote-amd64)
           - **Linux ARM64**: [swerex-remote-aarch64](https://github.com/' || '' }}${{ steps.release_info.outputs.type == 'version' && github.repository || '' }}${{ steps.release_info.outputs.type == 'version' && '/releases/latest/download/swerex-remote-aarch64)' || '' }}
         files: |
-          release_assets/swerex-remote-x86_64
+          release_assets/swerex-remote-amd64
           release_assets/swerex-remote-aarch64
           release_assets/checksums.txt
         prerelease: ${{ steps.release_info.outputs.prerelease }}

--- a/.github/workflows/release_swerex_remote.yaml
+++ b/.github/workflows/release_swerex_remote.yaml
@@ -38,7 +38,7 @@ jobs:
         
         # Install uv
         curl -LsSf https://astral.sh/uv/install.sh | sh
-        export PATH="$HOME/.cargo/bin:$PATH"
+        source $HOME/.local/bin/env
         
         # Create virtual environment with Python 3.13
         uv venv --python 3.13 .venv

--- a/.github/workflows/release_swerex_remote.yaml
+++ b/.github/workflows/release_swerex_remote.yaml
@@ -1,0 +1,127 @@
+name: Release swerex-remote Executable
+
+on:
+  push:
+    tags:
+      - 'v*' # Triggers on version tags like v1.0.0, v2.1.3, etc.
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build executable in Ubuntu 14.04 container
+      run: |
+        # Create build script
+        cat > build_script.sh << 'EOF'
+        #!/bin/bash
+        set -e
+        
+        # Update package lists
+        apt-get update
+        
+        # Install basic dependencies
+        apt-get install -y curl ca-certificates build-essential
+        
+        # Install uv
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.cargo/bin:$PATH"
+        
+        # Create virtual environment with Python 3.11
+        uv venv --python 3.13 .venv
+        source .venv/bin/activate
+        
+        # Install dependencies
+        uv pip install -e '.[dev]'
+        uv pip install pyinstaller
+        
+        # Build executable
+        pyinstaller src/swerex/server.py --onefile --name swerex-remote-$ARCH
+        
+        # Make executable and copy to output
+        chmod +x dist/swerex-remote-$ARCH
+        cp dist/swerex-remote-$ARCH /output/
+        EOF
+        
+        chmod +x build_script.sh
+        
+        # Create output directory
+        mkdir -p output
+        
+        # Build using Ubuntu 14.04 with emulation for cross-platform builds
+        docker run --rm \
+          --platform linux/${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64' }} \
+          -v $(pwd):/workspace \
+          -v $(pwd)/output:/output \
+          -w /workspace \
+          -e ARCH=${{ matrix.arch }} \
+          ubuntu:14.04 \
+          bash build_script.sh
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: swerex-remote-${{ matrix.arch }}
+        path: output/swerex-remote-${{ matrix.arch }}
+        retention-days: 30
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+
+    - name: Prepare release assets
+      run: |
+        mkdir -p release_assets
+        cp artifacts/swerex-remote-x86_64/swerex-remote-x86_64 release_assets/
+        cp artifacts/swerex-remote-aarch64/swerex-remote-aarch64 release_assets/
+        
+        # Create checksums
+        cd release_assets
+        sha256sum * > checksums.txt
+        cd ..
+
+    - name: Extract version from tag
+      id: version
+      run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+    - name: Create versioned release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.version.outputs.version }}
+        name: "Release ${{ steps.version.outputs.version }}"
+        body: |
+          Release ${{ steps.version.outputs.version }} of SWE-ReX remote server
+          
+          ## Download Links
+          - **Linux x86_64**: [swerex-remote-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/swerex-remote-x86_64)
+          - **Linux ARM64**: [swerex-remote-aarch64](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/swerex-remote-aarch64)
+          - **Checksums**: [checksums.txt](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/checksums.txt)
+          
+          ## Always Latest Links
+          - **Linux x86_64**: [swerex-remote-x86_64](https://github.com/${{ github.repository }}/releases/latest/download/swerex-remote-x86_64)
+          - **Linux ARM64**: [swerex-remote-aarch64](https://github.com/${{ github.repository }}/releases/latest/download/swerex-remote-aarch64)
+        files: |
+          release_assets/swerex-remote-x86_64
+          release_assets/swerex-remote-aarch64
+          release_assets/checksums.txt
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_swerex_remote.yaml
+++ b/.github/workflows/release_swerex_remote.yaml
@@ -2,8 +2,12 @@ name: Release swerex-remote Executable
 
 on:
   push:
+    branches: [ main ]
     tags:
       - 'v*' # Triggers on version tags like v1.0.0, v2.1.3, etc.
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: # Allow manual triggers
 
 jobs:
   build:
@@ -36,7 +40,7 @@ jobs:
         curl -LsSf https://astral.sh/uv/install.sh | sh
         export PATH="$HOME/.cargo/bin:$PATH"
         
-        # Create virtual environment with Python 3.11
+        # Create virtual environment with Python 3.13
         uv venv --python 3.13 .venv
         source .venv/bin/activate
         
@@ -77,6 +81,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' # Only create releases on push events (not PRs)
     
     steps:
     - name: Checkout code
@@ -98,30 +103,49 @@ jobs:
         sha256sum * > checksums.txt
         cd ..
 
-    - name: Extract version from tag
-      id: version
-      run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+    - name: Determine release type and details
+      id: release_info
+      run: |
+        if [[ $GITHUB_REF == refs/tags/v* ]]; then
+          # This is a version tag
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo "type=version" >> $GITHUB_OUTPUT
+          echo "tag=$VERSION" >> $GITHUB_OUTPUT
+          echo "name=Release $VERSION" >> $GITHUB_OUTPUT
+          echo "prerelease=false" >> $GITHUB_OUTPUT
+          echo "body=Release $VERSION of SWE-ReX remote server" >> $GITHUB_OUTPUT
+        else
+          # This is a dev build from main/master branch
+          DATE=$(date +'%Y%m%d-%H%M%S')
+          COMMIT_SHORT=$(echo $GITHUB_SHA | cut -c1-7)
+          echo "type=dev" >> $GITHUB_OUTPUT
+          echo "tag=dev-$DATE-$COMMIT_SHORT" >> $GITHUB_OUTPUT
+          echo "name=Development Build $DATE" >> $GITHUB_OUTPUT
+          echo "prerelease=true" >> $GITHUB_OUTPUT
+          echo "body=Development build from commit $GITHUB_SHA" >> $GITHUB_OUTPUT
+        fi
 
-    - name: Create versioned release
+    - name: Create or update release
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ steps.version.outputs.version }}
-        name: "Release ${{ steps.version.outputs.version }}"
+        tag_name: ${{ steps.release_info.outputs.tag }}
+        name: ${{ steps.release_info.outputs.name }}
         body: |
-          Release ${{ steps.version.outputs.version }} of SWE-ReX remote server
+          ${{ steps.release_info.outputs.body }}
           
           ## Download Links
-          - **Linux x86_64**: [swerex-remote-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/swerex-remote-x86_64)
-          - **Linux ARM64**: [swerex-remote-aarch64](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/swerex-remote-aarch64)
-          - **Checksums**: [checksums.txt](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/checksums.txt)
+          - **Linux x86_64**: [swerex-remote-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.tag }}/swerex-remote-x86_64)
+          - **Linux ARM64**: [swerex-remote-aarch64](https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.tag }}/swerex-remote-aarch64)
+          - **Checksums**: [checksums.txt](https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.tag }}/checksums.txt)
           
-          ## Always Latest Links
-          - **Linux x86_64**: [swerex-remote-x86_64](https://github.com/${{ github.repository }}/releases/latest/download/swerex-remote-x86_64)
-          - **Linux ARM64**: [swerex-remote-aarch64](https://github.com/${{ github.repository }}/releases/latest/download/swerex-remote-aarch64)
+          ${{ steps.release_info.outputs.type == 'version' && '## Always Latest Links
+          - **Linux x86_64**: [swerex-remote-x86_64](https://github.com/' || '' }}${{ steps.release_info.outputs.type == 'version' && github.repository || '' }}${{ steps.release_info.outputs.type == 'version' && '/releases/latest/download/swerex-remote-x86_64)
+          - **Linux ARM64**: [swerex-remote-aarch64](https://github.com/' || '' }}${{ steps.release_info.outputs.type == 'version' && github.repository || '' }}${{ steps.release_info.outputs.type == 'version' && '/releases/latest/download/swerex-remote-aarch64)' || '' }}
         files: |
           release_assets/swerex-remote-x86_64
           release_assets/swerex-remote-aarch64
           release_assets/checksums.txt
-        prerelease: false
+        prerelease: ${{ steps.release_info.outputs.prerelease }}
+        make_latest: ${{ steps.release_info.outputs.type == 'version' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         exclude: pyproject.toml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.8
+    rev: v0.12.10
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
### Motivation

Currently, we need to install swe-rex into the container using python. However, it is not compatible with some old OS versions, such as ubuntu 14/16, which is used in some security benchmarks. For example, for some containers in [the ARVO dataset](https://arxiv.org/abs/2408.02153), the OS version is old and python version is also too old to install this package.

```bash
root@bc9d66643156:/src/lcms# cat /etc/os-release 
NAME="Ubuntu"
VERSION="16.04.7 LTS (Xenial Xerus)"

root@bc9d66643156:/src/lcms# python3 -m pipx ensurepath
Python 3.8 or later is required. See https://github.com/pypa/pipx for installation instructions.
```

### Proposal

Use pre-built standalone executable for swe-rex remote server. It has the following benefits:
- Compatible with old OS versions. It is hard to use apt to install newer python versions on ubuntu 14/16. 
- Faster setup process. While it is possible to use uv/conda to install swe-rex to old OS versions, the process is repetitive so we can just pre-build it and use it.

### TODO list

- [ ] add a CI workflow to build swe-rex remote server and release it; support both amd64 and arm64
- [ ] use the pre-built executable after starting the container; we can download it from the latest release link from github (example for dev download links: https://github.com/Co1lin/SWE-ReX/releases)