### PR TITLE
Fix Hardcoded Region in Task Definition Log Group

### DIFF
--- a/src/swerex/deployment/fargate.py
+++ b/src/swerex/deployment/fargate.py
@@ -146,10 +146,12 @@ class FargateDeployment(AbstractDeployment):
         self.logger.info(f"Fargate container started in {time.time() - t0:.2f}s")
         if self._config.log_group:
             try:
+                region = ecs_client.meta.region_name
                 log_url = get_cloudwatch_log_url(
                     task_arn=self._task_arn,
                     task_definition=self._task_definition,
                     container_name=self._container_name,
+                    region=region,
                 )
                 self.logger.info(f"Monitor logs at: {log_url}")
             except Exception as e:

--- a/src/swerex/utils/aws.py
+++ b/src/swerex/utils/aws.py
@@ -98,6 +98,8 @@ def get_task_definition(
     log_group: str | None = None,
 ) -> str:
     ecs_client = boto3.client("ecs")
+    region = ecs_client.meta.region_name
+
     task_definition = {
         "executionRoleArn": execution_role_arn,
         "networkMode": "awsvpc",
@@ -122,7 +124,7 @@ def get_task_definition(
             "logDriver": "awslogs",
             "options": {
                 "awslogs-group": log_group,
-                "awslogs-region": "us-east-2",
+                "awslogs-region": region,
                 "awslogs-stream-prefix": "ecs",
                 "awslogs-create-group": "true",
             },


### PR DESCRIPTION
Fix hardcoded region in task definition log group. 
Region was previously hardcoded to us-east-2. Region is now dynamically determined from the environment and aligned with other resources in the setup

https://github.com/SWE-agent/SWE-ReX/issues/257