### PR TITLE
fix: Dynamic log group support in IAM execution role policy

### DIFF
--- a/src/swerex/deployment/fargate.py
+++ b/src/swerex/deployment/fargate.py
@@ -58,7 +58,9 @@ class FargateDeployment(AbstractDeployment):
 
     def _init_aws(self):
         self._cluster_arn = get_cluster_arn(self._config.cluster_name)
-        self._execution_role_arn = get_execution_role_arn(execution_role_prefix=self._config.execution_role_prefix)
+        self._execution_role_arn = get_execution_role_arn(
+            execution_role_prefix=self._config.execution_role_prefix, log_group=self._config.log_group
+        )
         self._task_definition = get_task_definition(
             image_name=self._config.image,
             port=self._config.port,


### PR DESCRIPTION
Fixes hardcoded log group in AWS IAM execution role policy that prevented using custom log groups with Fargate deployments.

Changes:
- Add log_group parameter to get_execution_role_arn() function
- Dynamically generate IAM policy with user-specified log group
- Remove unused secretsmanager:GetSecretValue permission

This allows users to specify custom CloudWatch log groups via FargateDeploymentConfig.log_group and ensures the execution role has appropriate permissions for the configured log group.


*Note*: This change removes the secretsManager. It is unclear on what its intended usage was previously, as the policy has a mixed SecretManager action with Cloudwatch resources and would never match

