### PR TITLE
fix for the situation where PS1 is modified

### DIFF
--- a/src/swerex/runtime/local.py
+++ b/src/swerex/runtime/local.py
@@ -55,12 +55,12 @@ from swerex.utils.log import get_logger
 __all__ = ["LocalRuntime", "BashSession"]
 
 
-def _split_bash_command(inpt: str) -> list[str]:
+def _split_bash_command(input: str) -> list[str]:
     r"""Split a bash command with linebreaks, escaped newlines, and heredocs into a list of
     individual commands.
 
     Args:
-        inpt: The input string to split into commands.
+        input: The input string to split into commands.
     Returns:
         A list of commands as strings.
 
@@ -70,11 +70,11 @@ def _split_bash_command(inpt: str) -> list[str]:
     "cmd1\\\n asdf" is one command (because the linebreak is escaped)
     "cmd1<<EOF\na\nb\nEOF" is one command (because of the heredoc)
     """
-    inpt = inpt.strip()
-    if not inpt or all(l.strip().startswith("#") for l in inpt.splitlines()):
+    input = input.strip()
+    if not input or all(l.strip().startswith("#") for l in input.splitlines()):
         # bashlex can't deal with empty strings or the like :/
         return []
-    parsed = bashlex.parse(inpt)
+    parsed = bashlex.parse(input)
     cmd_strings = []
 
     def find_range(cmd: bashlex.ast.node) -> tuple[int, int]:
@@ -88,7 +88,7 @@ def _split_bash_command(inpt: str) -> list[str]:
 
     for cmd in parsed:
         start, end = find_range(cmd)
-        cmd_strings.append(inpt[start:end])
+        cmd_strings.append(input[start:end])
     return cmd_strings
 
 


### PR DESCRIPTION
When the model performs some actions that modify the environment variable self._ps1 (for example, using venv virtual environment), the _run_normal function will get stuck and will never return.