### PR TITLE
Cloudflare Containers Deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "bashlex",
     "python-multipart",
     "rich",
+    "aiohttp>=3.13.3",
 ]
 
 [project.optional-dependencies]

--- a/src/swerex/deployment/cloudflare.py
+++ b/src/swerex/deployment/cloudflare.py
@@ -55,7 +55,8 @@ class CloudflareDeployment(AbstractDeployment):
             ) as resp:
                 if resp.status >= 400:
                     body = await resp.text()
-                    raise RuntimeError(f"CF Worker /start returned {resp.status}: {body}")
+                    msg = f"CF Worker /start returned {resp.status}: {body}"
+                    raise RuntimeError(msg)
                 data = await resp.json()
                 self._instance_id = data["instance_id"]
 

--- a/src/swerex/deployment/cloudflare.py
+++ b/src/swerex/deployment/cloudflare.py
@@ -3,7 +3,6 @@ import uuid
 from typing import Any
 
 import aiohttp
-from typing_extensions import Self
 
 from swerex.deployment.abstract import AbstractDeployment
 from swerex.deployment.config import CloudflareDeploymentConfig
@@ -16,11 +15,13 @@ from swerex.utils.wait import _wait_until_alive
 
 __all__ = ["CloudflareDeployment"]
 
+
 class CloudflareDeployment(AbstractDeployment):
     """Cloudflare deployment using Cloudflare Containers
     Requires a Cloudflare Worker to be deployed first.
     The worker manages container lifecycle via Durable Objects.
     """
+
     def __init__(
         self,
         *,

--- a/src/swerex/deployment/cloudflare.py
+++ b/src/swerex/deployment/cloudflare.py
@@ -1,0 +1,128 @@
+import logging
+import uuid
+from typing import Any
+
+import aiohttp
+from typing_extensions import Self
+
+from swerex.deployment.abstract import AbstractDeployment
+from swerex.deployment.config import CloudflareDeploymentConfig
+from swerex.deployment.hooks.abstract import CombinedDeploymentHook, DeploymentHook
+from swerex.exceptions import DeploymentNotStartedError
+from swerex.runtime.abstract import IsAliveResponse
+from swerex.runtime.remote import RemoteRuntime
+from swerex.utils.log import get_logger
+from swerex.utils.wait import _wait_until_alive
+
+__all__ = ["CloudflareDeployment"]
+
+class CloudflareDeployment(AbstractDeployment):
+    """Cloudflare deployment using Cloudflare Containers
+    Requires a Cloudflare Worker to be deployed first.
+    The worker manages container lifecycle via Durable Objects.
+    """
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger | None = None,
+        **kwargs: Any,
+    ):
+        self._config = CloudflareDeploymentConfig(**kwargs)
+        self._runtime: RemoteRuntime | None = None
+        self._instance_id: str | None = None
+        self.logger = logger or get_logger("rex-deploy")
+        self._hooks = CombinedDeploymentHook()
+
+    @classmethod
+    def from_config(cls, config: CloudflareDeploymentConfig):
+        return cls(**config.model_dump())
+
+    def add_hook(self, hook: DeploymentHook):
+        pass
+
+    async def start(self):
+        """Start a new container instance via the CF Worker and connect RemoteRuntime to it."""
+        auth_token = str(uuid.uuid4())
+        self._hooks.on_custom_step("Starting CF container")
+        self.logger.info(f"Starting CF container via {self._config.worker_url}")
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self._config.worker_url}/start",
+                json={"auth_token": auth_token},
+                headers=self._management_headers,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    raise RuntimeError(f"CF Worker /start returned {resp.status}: {body}")
+                data = await resp.json()
+                self._instance_id = data["instance_id"]
+
+        self.logger.info(f"Container instance created: {self._instance_id}")
+
+        # RemoteRuntime connects to the Worker URL prefixed with the instance ID.
+        # The Worker proxies /{instance_id}/... to the container via the DO.
+        proxy_url = f"{self._config.worker_url}/{self._instance_id}"
+        self._runtime = RemoteRuntime(
+            host=proxy_url,
+            port=None,
+            auth_token=auth_token,
+            timeout=self._config.runtime_timeout,
+        )
+
+        self._hooks.on_custom_step("Waiting for runtime")
+        self.logger.info(f"Waiting for runtime at {proxy_url}")
+        await _wait_until_alive(
+            self._runtime.is_alive,
+            timeout=self._config.startup_timeout,
+            function_timeout=self._config.runtime_timeout,
+        )
+        self.logger.info("CF container runtime is ready")
+
+    async def stop(self):
+        """Close the runtime and stop the container instance."""
+        if self._runtime is not None:
+            try:
+                await self._runtime.close()
+            except Exception:
+                self.logger.warning("Failed to close runtime gracefully", exc_info=True)
+            self._runtime = None
+
+        if self._instance_id is not None:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.delete(
+                        f"{self._config.worker_url}/stop/{self._instance_id}",
+                        headers=self._management_headers,
+                        timeout=aiohttp.ClientTimeout(total=15),
+                    ) as resp:
+                        resp.raise_for_status()
+            except Exception:
+                self.logger.warning(
+                    f"Failed to stop container {self._instance_id}",
+                    exc_info=True,
+                )
+            self._instance_id = None
+
+    @property
+    def runtime(self) -> RemoteRuntime:
+        """Returns the runtime if running.
+
+        Raises:
+            DeploymentNotStartedError: If the deployment was not started.
+        """
+        if self._runtime is None:
+            raise DeploymentNotStartedError()
+        return self._runtime
+
+    @property
+    def _management_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self._config.worker_api_token:
+            headers["Authorization"] = f"Bearer {self._config.worker_api_token}"
+        return headers
+
+    async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
+        if self._runtime is None:
+            raise DeploymentNotStartedError()
+        return await self._runtime.is_alive(timeout=timeout)

--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -210,6 +210,35 @@ class DaytonaDeploymentConfig(BaseModel):
 
         return DaytonaDeployment.from_config(self)
 
+class CloudflareDeploymentConfig(BaseModel):
+    """Configuration for Cloudflare Container deployment.
+
+    Requires a Cloudflare Worker (from cf-python-worker/) to be deployed.
+    The worker manages container instances via Durable Objects.
+    """
+
+    worker_url: str
+    """URL of the deployed Cloudflare Worker (e.g. https://swerex-cf-container.example.workers.dev)."""
+
+    worker_api_token: str = ""
+    """Bearer token for authenticating management requests to the CF Worker (optional)."""
+
+    startup_timeout: float = 300.0
+    """Time (seconds) to wait for the container to be ready."""
+
+    runtime_timeout: float = 30.0
+    """Timeout (seconds) for individual runtime HTTP requests."""
+
+    type: Literal["cf_container"] = "cf_container"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.cloudflare import CloudflareDeployment
+
+        return CloudflareDeployment.from_config(self)
+
 
 DeploymentConfig = (
     LocalDeploymentConfig
@@ -219,6 +248,7 @@ DeploymentConfig = (
     | RemoteDeploymentConfig
     | DummyDeploymentConfig
     | DaytonaDeploymentConfig
+    | CloudflareDeploymentConfig
 )
 """Union of all deployment configurations. Useful for type hints."""
 

--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -210,6 +210,7 @@ class DaytonaDeploymentConfig(BaseModel):
 
         return DaytonaDeployment.from_config(self)
 
+
 class CloudflareDeploymentConfig(BaseModel):
     """Configuration for Cloudflare Container deployment.
 

--- a/tests/test_cloudflare_deployment.py
+++ b/tests/test_cloudflare_deployment.py
@@ -63,8 +63,10 @@ async def test_start_sets_instance_id_and_runtime():
     d = CloudflareDeployment(worker_url="https://fake.workers.dev")
     session = _make_mock_session(post_json={"instance_id": "abc123"})
 
-    with patch("aiohttp.ClientSession", return_value=session), \
-         patch("swerex.deployment.cloudflare._wait_until_alive", new_callable=AsyncMock):
+    with (
+        patch("aiohttp.ClientSession", return_value=session),
+        patch("swerex.deployment.cloudflare._wait_until_alive", new_callable=AsyncMock),
+    ):
         await d.start()
 
     assert d._instance_id == "abc123"
@@ -75,8 +77,10 @@ async def test_start_uses_correct_worker_url():
     d = CloudflareDeployment(worker_url="https://fake.workers.dev", worker_api_token="tok")
     session = _make_mock_session()
 
-    with patch("aiohttp.ClientSession", return_value=session), \
-         patch("swerex.deployment.cloudflare._wait_until_alive", new_callable=AsyncMock):
+    with (
+        patch("aiohttp.ClientSession", return_value=session),
+        patch("swerex.deployment.cloudflare._wait_until_alive", new_callable=AsyncMock),
+    ):
         await d.start()
 
     call_args = session.post.call_args
@@ -130,6 +134,7 @@ async def test_stop_continues_if_runtime_close_fails():
 
 
 # --- Integration tests (require a live CF worker) ---
+
 
 @pytest.mark.cloud
 @pytest.mark.slow

--- a/tests/test_cloudflare_deployment.py
+++ b/tests/test_cloudflare_deployment.py
@@ -1,0 +1,147 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from swerex.deployment.cloudflare import CloudflareDeployment
+from swerex.exceptions import DeploymentNotStartedError
+
+
+def _make_async_cm(obj):
+    """Wrap obj so it works as an async context manager returning itself."""
+    obj.__aenter__ = AsyncMock(return_value=obj)
+    obj.__aexit__ = AsyncMock(return_value=False)
+    return obj
+
+
+def _make_mock_session(post_status=200, post_json=None, delete_status=200):
+    """Build a mock aiohttp.ClientSession context manager."""
+    post_resp = AsyncMock()
+    post_resp.status = post_status
+    post_resp.json = AsyncMock(return_value=post_json or {"instance_id": "abc123"})
+    post_resp.text = AsyncMock(return_value="error body")
+    _make_async_cm(post_resp)
+
+    delete_resp = AsyncMock()
+    delete_resp.status = delete_status
+    delete_resp.raise_for_status = MagicMock()
+    _make_async_cm(delete_resp)
+
+    # post/delete must be MagicMock (not AsyncMock) — they're used as `async with session.post(...)`
+    # which means they must return an async context manager, not a coroutine.
+    session = MagicMock()
+    session.post.return_value = post_resp
+    session.delete.return_value = delete_resp
+    _make_async_cm(session)
+
+    return session
+
+
+async def test_not_started_raises():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev")
+    with pytest.raises(DeploymentNotStartedError):
+        await d.is_alive()
+
+
+async def test_runtime_property_raises_when_not_started():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev")
+    with pytest.raises(DeploymentNotStartedError):
+        _ = d.runtime
+
+
+async def test_management_headers_with_token():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev", worker_api_token="mytoken")
+    assert d._management_headers == {"Authorization": "Bearer mytoken"}
+
+
+async def test_management_headers_without_token():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev")
+    assert d._management_headers == {}
+
+
+async def test_start_sets_instance_id_and_runtime():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev")
+    session = _make_mock_session(post_json={"instance_id": "abc123"})
+
+    with patch("aiohttp.ClientSession", return_value=session), \
+         patch("swerex.deployment.cloudflare._wait_until_alive", new_callable=AsyncMock):
+        await d.start()
+
+    assert d._instance_id == "abc123"
+    assert d._runtime is not None
+
+
+async def test_start_uses_correct_worker_url():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev", worker_api_token="tok")
+    session = _make_mock_session()
+
+    with patch("aiohttp.ClientSession", return_value=session), \
+         patch("swerex.deployment.cloudflare._wait_until_alive", new_callable=AsyncMock):
+        await d.start()
+
+    call_args = session.post.call_args
+    assert call_args[0][0] == "https://fake.workers.dev/start"
+    assert call_args[1]["headers"] == {"Authorization": "Bearer tok"}
+
+
+async def test_start_raises_on_worker_error():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev")
+    session = _make_mock_session(post_status=500)
+
+    with patch("aiohttp.ClientSession", return_value=session):
+        with pytest.raises(RuntimeError, match="CF Worker /start returned 500"):
+            await d.start()
+
+
+async def test_stop_calls_delete_endpoint():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev")
+    d._instance_id = "abc123"
+    d._runtime = AsyncMock()
+    d._runtime.close = AsyncMock()
+
+    session = _make_mock_session()
+    with patch("aiohttp.ClientSession", return_value=session):
+        await d.stop()
+
+    call_args = session.delete.call_args
+    assert call_args[0][0] == "https://fake.workers.dev/stop/abc123"
+    assert d._instance_id is None
+    assert d._runtime is None
+
+
+async def test_stop_is_idempotent():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev")
+    # stop before start should not raise
+    await d.stop()
+    await d.stop()
+
+
+async def test_stop_continues_if_runtime_close_fails():
+    d = CloudflareDeployment(worker_url="https://fake.workers.dev")
+    d._instance_id = "abc123"
+    d._runtime = AsyncMock()
+    d._runtime.close = AsyncMock(side_effect=Exception("close failed"))
+
+    session = _make_mock_session()
+    with patch("aiohttp.ClientSession", return_value=session):
+        await d.stop()  # should not raise
+
+    assert d._instance_id is None
+
+
+# --- Integration tests (require a live CF worker) ---
+
+@pytest.mark.cloud
+@pytest.mark.slow
+@pytest.mark.skipif(not os.getenv("CF_WORKER_URL"), reason="CF_WORKER_URL not set")
+async def test_cloudflare_deployment_full():
+    d = CloudflareDeployment(
+        worker_url=os.environ["CF_WORKER_URL"],
+        worker_api_token=os.getenv("CF_WORKER_API_TOKEN", ""),
+        startup_timeout=120,
+    )
+    with pytest.raises(DeploymentNotStartedError):
+        await d.is_alive()
+    await d.start()
+    assert await d.is_alive()
+    await d.stop()


### PR DESCRIPTION
 - Adds CloudflareDeployment + CloudflareDeploymentConfig for running SWE-ReX runtimes on Cloudflare Containers, using a CF Worker to manage container lifecycle (start/stop) via Durable Objects
  - Container instances are provisioned on-demand with a per-session auth token; RemoteRuntime connects through the Worker's proxy URL (worker_url/{instance_id})

Write up [here](https://dattabytes.xyz/cf-containers-swe-rex/)