### PR TITLE
fix: prevent heredoc command injection in _check_bash_command

### DIFF
--- a/src/swerex/runtime/local.py
+++ b/src/swerex/runtime/local.py
@@ -99,14 +99,21 @@ def _strip_control_chars(s: str) -> str:
 
 
 def _check_bash_command(command: str) -> None:
-    """Check if a bash command is valid. Raises BashIncorrectSyntaxError if it's not."""
-    _unique_string = "SOUNIQUEEOF"
-    cmd = f"/usr/bin/env bash -n << '{_unique_string}'\n{command}\n{_unique_string}"
-    result = subprocess.run(cmd, shell=True, capture_output=True)
+    """Check if a bash command is valid. Raises BashIncorrectSyntaxError if it's not.
+
+    Uses stdin pipe instead of heredoc + shell=True to avoid command injection
+    through heredoc delimiter bypass.
+    """
+    result = subprocess.run(
+        ["bash", "-n"],
+        input=command,
+        text=True,
+        capture_output=True,
+    )
     if result.returncode == 0:
         return
-    stdout = result.stdout.decode(errors="backslashreplace")
-    stderr = result.stderr.decode(errors="backslashreplace")
+    stdout = result.stdout or ""
+    stderr = result.stderr or ""
     msg = (
         f"Error (exit code {result.returncode}) while checking bash command \n{command!r}\n"
         f"---- Stderr ----\n{stderr}\n---- Stdout ----\n{stdout}"


### PR DESCRIPTION
## Summary

Fix command injection vulnerability in `_check_bash_command()` via heredoc delimiter bypass.

## Vulnerability

The function used `shell=True` with a heredoc to pass bash commands to `bash -n`. The heredoc delimiter `SOUNIQUEEOF` was hardcoded. An attacker controlling the command string could inject this delimiter to break out of the heredoc and execute arbitrary shell commands via `shell=True`.

## Fix

Replace `subprocess.run(cmd, shell=True)` with `subprocess.run(["bash", "-n"], input=command)`, which passes the command via stdin pipe instead of heredoc. Eliminates `shell=True` and prevents delimiter injection.
