### PR TITLE
Add TenkiDeployment for running on Tenki sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pip install 'swe-rex[modal]'
 pip install 'swe-rex[fargate]'
 # With daytona support (WIP)
 pip install 'swe-rex[daytona]'
+# With tenki support
+pip install 'swe-rex[tenki]'
 # Development setup (all optional dependencies)
 pip install 'swe-rex[dev]'
 ```

--- a/docs/api/deployments/tenki.md
+++ b/docs/api/deployments/tenki.md
@@ -1,0 +1,1 @@
+::: swerex.deployment.tenki.TenkiDeployment

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,6 +8,8 @@ pip install swe-rex
 pip install 'swe-rex[modal]'
 # With fargate support
 pip install 'swe-rex[fargate]'
+# With tenki support
+pip install 'swe-rex[tenki]'
 # Development setup (all optional dependencies)
 pip install 'swe-rex[dev]'
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,4 +121,27 @@ output='' exit_code=0 failure_reason='' expect_string='SHELLPS1PREFIX' session_t
 output='test\n' exit_code=0 failure_reason='' expect_string='SHELLPS1PREFIX' session_type='bash'
 🦖 DEBUG    Ensuring deployment is stopped because object is deleted          
 ```
+
+## Running with Tenki
+
+You can also run in a [Tenki](https://tenki.cloud) sandbox by using the `TenkiDeployment`.
+Generate an API key in your Tenki workspace settings and set it as the `TENKI_API_KEY`
+environment variable (or pass it explicitly as `api_key`).
+
+```python
+from swerex.deployment.tenki import TenkiDeployment
+
+async def run_tenki_deployment():
+    deployment = TenkiDeployment(
+        startup_timeout=180,  # wait up to 3 minutes for the runtime to start
+        container_timeout=3600,  # kill the sandbox after 1 hour
+    )
+    await deployment.start()
+    await deployment.is_alive()
+    return deployment
+
+deployment = asyncio.run(run_tenki_deployment())
+asyncio.run(run_some_stuff(deployment))
+```
+
 {% include-markdown "_footer.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Docker: api/deployments/docker.md
       - Modal: api/deployments/modal.md
       - Fargate: api/deployments/fargate.md
+      - Tenki: api/deployments/tenki.md
       - Dummy: api/deployments/dummy.md
     - Runtimes classes:
       - Abstract: api/runtimes/abstract.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "swe-rex[modal]",
     "swe-rex[fargate]",
     "swe-rex[daytona]",
+    "swe-rex[tenki]",
 ]
 modal = [
     "modal>=1.0",
@@ -67,6 +68,9 @@ fargate = [
 daytona = [
     "daytona",
     "daytona-sdk >= 0.21",
+]
+tenki = [
+    "tenki-sandbox",
 ]
 
 [tool.setuptools]

--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -253,6 +253,12 @@ class TenkiDeploymentConfig(BaseModel):
     runtime_timeout: float = Field(
         default=60.0, description="Runtime timeout (default timeout for all runtime requests)"
     )
+    runtime_retries: int = Field(
+        default=3,
+        description="How often the runtime retries requests that fail with connection errors. "
+        "Transient connection errors can occur on the preview gateway; retrying is safe because "
+        "requests carry an idempotency key.",
+    )
     sandbox_kwargs: dict[str, Any] = Field(
         default_factory=dict, description="Additional keyword arguments to pass to `tenki_sandbox.Sandbox.create`"
     )

--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -211,6 +211,63 @@ class DaytonaDeploymentConfig(BaseModel):
         return DaytonaDeployment.from_config(self)
 
 
+class TenkiDeploymentConfig(BaseModel):
+    """Configuration for running in a Tenki sandbox (https://tenki.cloud)."""
+
+    api_key: str = Field(
+        default="",
+        description="Tenki API key. Falls back to the TENKI_AUTH_TOKEN/TENKI_API_KEY environment variables if empty.",
+    )
+    base_url: str = Field(
+        default="",
+        description="Tenki API base URL. Falls back to the TENKI_API_ENDPOINT environment variable or https://api.tenki.cloud if empty.",
+    )
+    project_id: str = Field(
+        default="",
+        description="Tenki project to create the sandbox in. If empty, the project is resolved automatically (only possible if the API key has access to exactly one project).",
+    )
+    workspace_id: str = Field(
+        default="",
+        description="Tenki workspace to create the sandbox in. Usually not needed, as the workspace is implied by the project.",
+    )
+    image: str | None = Field(
+        default=None, description="Image to use for the sandbox. Uses the Tenki service default if None."
+    )
+    snapshot_id: str | None = Field(
+        default=None, description="Tenki snapshot to restore the sandbox from (alternative to image)."
+    )
+    cpu_cores: int | None = Field(
+        default=None, description="Number of CPU cores for the sandbox. Uses the Tenki service default if None."
+    )
+    memory_mb: int | None = Field(
+        default=None, description="Memory in MB for the sandbox. Uses the Tenki service default if None."
+    )
+    disk_size_gb: int | None = Field(
+        default=None, description="Disk size in GB for the sandbox. Uses the Tenki service default if None."
+    )
+    port: int = Field(default=8000, description="Port to expose for the SWE Rex server")
+    container_timeout: float = Field(
+        default=60 * 15, description="Timeout for the sandbox (also used as its max duration)"
+    )
+    startup_timeout: float = Field(default=180.0, description="The time to wait for the runtime to start")
+    runtime_timeout: float = Field(
+        default=60.0, description="Runtime timeout (default timeout for all runtime requests)"
+    )
+    sandbox_kwargs: dict[str, Any] = Field(
+        default_factory=dict, description="Additional keyword arguments to pass to `tenki_sandbox.Sandbox.create`"
+    )
+
+    type: Literal["tenki"] = "tenki"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.tenki import TenkiDeployment
+
+        return TenkiDeployment.from_config(self)
+
+
 DeploymentConfig = (
     LocalDeploymentConfig
     | DockerDeploymentConfig
@@ -219,6 +276,7 @@ DeploymentConfig = (
     | RemoteDeploymentConfig
     | DummyDeploymentConfig
     | DaytonaDeploymentConfig
+    | TenkiDeploymentConfig
 )
 """Union of all deployment configurations. Useful for type hints."""
 

--- a/src/swerex/deployment/tenki.py
+++ b/src/swerex/deployment/tenki.py
@@ -171,6 +171,7 @@ class TenkiDeployment(AbstractDeployment):
             port=None,
             auth_token=self._auth_token,
             timeout=self._config.runtime_timeout,
+            num_retries=self._config.runtime_retries,
             logger=self.logger,
         )
 
@@ -181,7 +182,11 @@ class TenkiDeployment(AbstractDeployment):
     async def stop(self):
         """Stops the runtime and terminates the Tenki sandbox."""
         if self._runtime is not None:
-            await self._runtime.close()
+            try:
+                await self._runtime.close()
+            except Exception as e:
+                # Closing the runtime must not prevent the sandbox from being terminated
+                self.logger.error(f"Failed to close runtime: {e}")
             self._runtime = None
 
         if self._sandbox is not None:

--- a/src/swerex/deployment/tenki.py
+++ b/src/swerex/deployment/tenki.py
@@ -1,0 +1,208 @@
+import logging
+import time
+import uuid
+from typing import Any
+
+from tenki_sandbox import Client, Sandbox
+from typing_extensions import Self
+
+from swerex import PACKAGE_NAME, REMOTE_EXECUTABLE_NAME
+from swerex.deployment.abstract import AbstractDeployment
+from swerex.deployment.config import TenkiDeploymentConfig
+from swerex.deployment.hooks.abstract import CombinedDeploymentHook, DeploymentHook
+from swerex.exceptions import DeploymentNotStartedError
+from swerex.runtime.abstract import IsAliveResponse
+from swerex.runtime.remote import RemoteRuntime
+from swerex.utils.log import get_logger
+from swerex.utils.wait import _wait_until_alive
+
+__all__ = ["TenkiDeployment", "TenkiDeploymentConfig"]
+
+
+class TenkiDeployment(AbstractDeployment):
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger | None = None,
+        **kwargs: Any,
+    ):
+        """Deployment for running the SWE-ReX server in a Tenki sandbox (https://tenki.cloud).
+
+        Args:
+            **kwargs: Keyword arguments (see `TenkiDeploymentConfig` for details).
+        """
+        self._config = TenkiDeploymentConfig(**kwargs)
+        self._runtime: RemoteRuntime | None = None
+        self._sandbox: Sandbox | None = None
+        self._sandbox_id = None
+        self._auth_token = None
+        self.logger = logger or get_logger("rex-deploy")
+        self._hooks = CombinedDeploymentHook()
+
+    def add_hook(self, hook: DeploymentHook):
+        self._hooks.add_hook(hook)
+
+    @classmethod
+    def from_config(cls, config: TenkiDeploymentConfig) -> Self:
+        return cls(**config.model_dump())
+
+    def _get_token(self) -> str:
+        """Generate a unique authentication token."""
+        return str(uuid.uuid4())
+
+    def _get_client_kwargs(self) -> dict[str, Any]:
+        client_kwargs: dict[str, Any] = {}
+        if self._config.api_key:
+            client_kwargs["auth_token"] = self._config.api_key
+        if self._config.base_url:
+            client_kwargs["base_url"] = self._config.base_url
+        return client_kwargs
+
+    def _resolve_project_id(self) -> str:
+        """Resolve the project to create the sandbox in from the API key's identity.
+
+        Raises:
+            RuntimeError: If the API key has access to more than one project.
+        """
+        client = Client(**self._get_client_kwargs())
+        identity = client.who_am_i()
+        projects = [project.id for workspace in identity.workspaces for project in workspace.projects]
+        if len(projects) != 1:
+            msg = (
+                f"Could not resolve the Tenki project automatically (found {len(projects)} projects). "
+                "Please set project_id in the deployment configuration."
+            )
+            raise RuntimeError(msg)
+        return projects[0]
+
+    def _get_command(self, *, token: str) -> str:
+        """Generate the command to run the SWE Rex server."""
+        main_command = f"{REMOTE_EXECUTABLE_NAME} --port {self._config.port} --auth-token {token}"
+        fallback_commands = [
+            # The default Tenki image runs as a non-root user with passwordless sudo
+            "SUDO=; if [ $(id -u) -ne 0 ] && command -v sudo > /dev/null; then SUDO=sudo; fi",
+            "$SUDO apt-get update -y",
+            "$SUDO apt-get install pipx -y",
+            "pipx ensurepath",
+            f"pipx run {PACKAGE_NAME} --port {self._config.port} --auth-token {token}",
+        ]
+        fallback_script = " && ".join(fallback_commands)
+        inner_command = f"{main_command} || ( {fallback_script} )"
+        # `exec` streams the command's output until it closes, so the server is
+        # backgrounded with its streams detached (see the Tenki docs on port exposure).
+        return (
+            f"timeout {self._config.container_timeout}s bash -c '{inner_command}' > /tmp/swerex.log 2>&1 < /dev/null &"
+        )
+
+    async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
+        """Checks if the runtime is alive.
+
+        Raises:
+            DeploymentNotStartedError: If the deployment was not started.
+        """
+        if self._runtime is None or self._sandbox is None:
+            raise DeploymentNotStartedError()
+
+        try:
+            self._sandbox.refresh()
+            state = self._sandbox.state
+        except Exception as e:
+            msg = f"Error checking Tenki sandbox status: {e}"
+            raise RuntimeError(msg)
+        if state != "RUNNING":
+            msg = f"Tenki sandbox is not running (state: {state})"
+            raise RuntimeError(msg)
+
+        return await self._runtime.is_alive(timeout=timeout)
+
+    async def _wait_until_alive(self, timeout: float):
+        """Wait until the runtime is alive."""
+        return await _wait_until_alive(self.is_alive, timeout=timeout, function_timeout=self._config.runtime_timeout)
+
+    async def start(self):
+        """Starts the runtime in a Tenki sandbox."""
+        self.logger.info("Creating Tenki sandbox...")
+
+        create_kwargs: dict[str, Any] = {
+            "name": f"swe-rex-{uuid.uuid4().hex[:8]}",
+            "project_id": self._config.project_id or self._resolve_project_id(),
+            # Inbound is required to expose the server port, outbound for the
+            # pipx fallback installation of swe-rex.
+            "allow_inbound": True,
+            "allow_outbound": True,
+            # Kill switch so that a forgotten sandbox doesn't run forever.
+            "max_duration": self._config.container_timeout,
+        }
+        create_kwargs.update(self._get_client_kwargs())
+        if self._config.workspace_id:
+            create_kwargs["workspace_id"] = self._config.workspace_id
+        if self._config.image is not None:
+            create_kwargs["image"] = self._config.image
+        if self._config.snapshot_id is not None:
+            create_kwargs["snapshot_id"] = self._config.snapshot_id
+        if self._config.cpu_cores is not None:
+            create_kwargs["cpu_cores"] = self._config.cpu_cores
+        if self._config.memory_mb is not None:
+            create_kwargs["memory_mb"] = self._config.memory_mb
+        if self._config.disk_size_gb is not None:
+            create_kwargs["disk_size_gb"] = self._config.disk_size_gb
+        create_kwargs.update(self._config.sandbox_kwargs)
+
+        # Waits until the sandbox is RUNNING and exec-ready
+        self._sandbox = Sandbox.create(**create_kwargs)
+        self._sandbox_id = self._sandbox.id
+        self.logger.info(f"Created Tenki sandbox with ID: {self._sandbox_id}")
+
+        self._auth_token = self._get_token()
+
+        command = self._get_command(token=self._auth_token)
+        self.logger.info("Starting SWE Rex server in Tenki sandbox...")
+        result = self._sandbox.exec("bash", "-lc", command)
+        if result.exit_code != 0:
+            self.logger.error(f"Failed to start SWE Rex server: {result.stderr_text}")
+            await self.stop()
+            msg = f"Failed to start SWE Rex server: {result.stderr_text}"
+            raise RuntimeError(msg)
+
+        preview = self._sandbox.expose_port(self._config.port, ttl=self._config.container_timeout)
+
+        self._runtime = RemoteRuntime(
+            host=preview.url,
+            port=None,
+            auth_token=self._auth_token,
+            timeout=self._config.runtime_timeout,
+            logger=self.logger,
+        )
+
+        t0 = time.time()
+        await self._wait_until_alive(timeout=self._config.startup_timeout)
+        self.logger.info(f"Runtime started in {time.time() - t0:.2f}s")
+
+    async def stop(self):
+        """Stops the runtime and terminates the Tenki sandbox."""
+        if self._runtime is not None:
+            await self._runtime.close()
+            self._runtime = None
+
+        if self._sandbox is not None:
+            try:
+                self.logger.info(f"Terminating Tenki sandbox with ID: {self._sandbox_id}")
+                self._sandbox.close_if_open()
+                self.logger.info("Tenki sandbox terminated successfully")
+            except Exception as e:
+                self.logger.error(f"Failed to terminate Tenki sandbox: {e}")
+
+        self._sandbox = None
+        self._sandbox_id = None
+        self._auth_token = None
+
+    @property
+    def runtime(self) -> RemoteRuntime:
+        """Returns the runtime if running.
+
+        Raises:
+            DeploymentNotStartedError: If the deployment was not started.
+        """
+        if self._runtime is None:
+            raise DeploymentNotStartedError()
+        return self._runtime

--- a/src/swerex/runtime/config.py
+++ b/src/swerex/runtime/config.py
@@ -28,6 +28,13 @@ class RemoteRuntimeConfig(BaseModel):
     """The port to connect to."""
     timeout: float = 0.15
     """The timeout for the runtime."""
+    num_retries: int = 0
+    """How often to retry requests that fail with connection errors.
+    Retries reuse the same idempotency key (`X-Request-ID` header), so the server
+    will not execute a request twice if it already processed it.
+    This is useful for deployments that connect through the public internet
+    (e.g., cloud sandboxes), where transient connection errors can occur.
+    """
 
     type: Literal["remote"] = "remote"
     """Discriminator for (de)serialization/CLI. Do not change."""

--- a/src/swerex/runtime/remote.py
+++ b/src/swerex/runtime/remote.py
@@ -162,8 +162,12 @@ class RemoteRuntime(AbstractRuntime):
     async def wait_until_alive(self, *, timeout: float = 60.0):
         return await _wait_until_alive(self.is_alive, timeout=timeout)
 
-    async def _request(self, endpoint: str, payload: BaseModel | None, output_class: Any, num_retries: int = 0):
+    async def _request(
+        self, endpoint: str, payload: BaseModel | None, output_class: Any, num_retries: int | None = None
+    ):
         """Small helper to make requests to the server and handle errors and output."""
+        if num_retries is None:
+            num_retries = self._config.num_retries
         request_url = f"{self._api_url}/{endpoint}"
         request_id = str(uuid.uuid4())
         headers = self._headers.copy()
@@ -184,6 +188,10 @@ class RemoteRuntime(AbstractRuntime):
                     ) as resp:
                         await self._handle_response_errors(resp)
                         return output_class(**await resp.json())
+            except SwerexException:
+                # Exceptions transferred from the server (e.g., a failing command)
+                # are not connection issues, so retrying would not help
+                raise
             except Exception as e:
                 last_exception = e
                 retry_count += 1

--- a/tests/test_get_deployment.py
+++ b/tests/test_get_deployment.py
@@ -8,6 +8,7 @@ from swerex.deployment.config import (
     LocalDeploymentConfig,
     ModalDeploymentConfig,
     RemoteDeploymentConfig,
+    TenkiDeploymentConfig,
 )
 from swerex.deployment.daytona import DaytonaDeployment
 from swerex.deployment.docker import DockerDeployment
@@ -15,6 +16,7 @@ from swerex.deployment.fargate import FargateDeployment
 from swerex.deployment.local import LocalDeployment
 from swerex.deployment.modal import ModalDeployment
 from swerex.deployment.remote import RemoteDeployment
+from swerex.deployment.tenki import TenkiDeployment
 
 
 def test_get_local_deployment():
@@ -45,6 +47,11 @@ def test_get_fargate_deployment():
 def test_get_daytona_deployment():
     deployment = get_deployment(DaytonaDeploymentConfig(image="test"))
     assert isinstance(deployment, DaytonaDeployment)
+
+
+def test_get_tenki_deployment():
+    deployment = get_deployment(TenkiDeploymentConfig(api_key="test"))
+    assert isinstance(deployment, TenkiDeployment)
 
 
 if __name__ == "__main__":

--- a/tests/test_tenki_deployment.py
+++ b/tests/test_tenki_deployment.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+
+from swerex.deployment.tenki import TenkiDeployment
+from swerex.runtime.abstract import Command
+
+
+@pytest.mark.cloud
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not (os.getenv("TENKI_AUTH_TOKEN") or os.getenv("TENKI_API_KEY")),
+    reason="Tenki credentials not set (TENKI_AUTH_TOKEN or TENKI_API_KEY)",
+)
+async def test_tenki_deployment():
+    d = TenkiDeployment(startup_timeout=60 * 10)
+    with pytest.raises(RuntimeError):
+        await d.is_alive()
+    await d.start()
+    assert await d.is_alive()
+    response = await d.runtime.execute(Command(command="echo 'hello world'", shell=True))
+    assert response.exit_code == 0
+    assert "hello world" in response.stdout
+    await d.stop()


### PR DESCRIPTION
## Summary

This PR adds a new deployment backend for [Tenki Sandbox](https://tenki.cloud), which provides disposable Linux microVMs for AI agents. It follows the same pattern as the existing `DaytonaDeployment`/`ModalDeployment`:

- `TenkiDeployment` (`src/swerex/deployment/tenki.py`) starts the SWE-ReX server inside a Tenki sandbox and connects to it through Tenki's port-exposure preview URL with a per-deployment auth token.
- `TenkiDeploymentConfig` with the usual knobs (`image`/`snapshot_id`, `cpu_cores`/`memory_mb`/`disk_size_gb`, `startup_timeout`/`runtime_timeout`/`container_timeout`, plus a `sandbox_kwargs` passthrough to `tenki_sandbox.Sandbox.create`).
- New optional dependency: `pip install 'swe-rex[tenki]'` (added to the `dev` extra as well).
- Docs: installation, usage tutorial section, and API reference page.

## Usage

```python
from swerex.deployment.tenki import TenkiDeployment

deployment = TenkiDeployment()  # reads TENKI_API_KEY from the environment
await deployment.start()
runtime = deployment.runtime  # a regular RemoteRuntime
...
await deployment.stop()
```

Credentials resolve the same way as in the Tenki SDK (`api_key` config field, falling back to `TENKI_AUTH_TOKEN`/`TENKI_API_KEY`). If the API key has access to exactly one project, the project is resolved automatically; otherwise `project_id` must be set.

Implementation notes:
- If the image does not ship `swerex-remote`, the deployment falls back to installing it with pipx (via passwordless `sudo` when running as the default non-root sandbox user).
- The sandbox is created with `max_duration=container_timeout` as a cost kill switch, and is terminated on `stop()`.

## Testing

- `tests/test_get_deployment.py::test_get_tenki_deployment` (unit).
- `tests/test_tenki_deployment.py::test_tenki_deployment` (marked `cloud`/`slow`, skipped unless `TENKI_API_KEY`/`TENKI_AUTH_TOKEN` is set): full lifecycle against the real service — create sandbox, start server, `is_alive`, execute a command through the `RemoteRuntime`, stop. Passes in ~40 s end to end.
- `pre-commit` (typos, ruff, ruff-format) passes on all changed files.