### PR TITLE
Add TenkiDeployment for running on Tenki sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pip install 'swe-rex[modal]'
 pip install 'swe-rex[fargate]'
 # With daytona support (WIP)
 pip install 'swe-rex[daytona]'
+# With tenki support
+pip install 'swe-rex[tenki]'
 # Development setup (all optional dependencies)
 pip install 'swe-rex[dev]'
 ```

--- a/docs/api/deployments/tenki.md
+++ b/docs/api/deployments/tenki.md
@@ -1,0 +1,1 @@
+::: swerex.deployment.tenki.TenkiDeployment

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,6 +8,8 @@ pip install swe-rex
 pip install 'swe-rex[modal]'
 # With fargate support
 pip install 'swe-rex[fargate]'
+# With tenki support
+pip install 'swe-rex[tenki]'
 # Development setup (all optional dependencies)
 pip install 'swe-rex[dev]'
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -131,17 +131,15 @@ environment variable (or pass it explicitly as `api_key`).
 ```python
 from swerex.deployment.tenki import TenkiDeployment
 
-async def run_tenki_deployment():
-    deployment = TenkiDeployment(
-        startup_timeout=180,  # wait up to 3 minutes for the runtime to start
-        container_timeout=3600,  # kill the sandbox after 1 hour
-    )
-    await deployment.start()
-    await deployment.is_alive()
-    return deployment
-
-deployment = asyncio.run(run_tenki_deployment())
+deployment = TenkiDeployment(
+    startup_timeout=180,  # wait up to 3 minutes for the runtime to start
+    container_timeout=3600,  # kill the sandbox after 1 hour
+)
 asyncio.run(run_some_stuff(deployment))
 ```
+
+Note that `run_some_stuff` already calls `deployment.start()` and `deployment.stop()`,
+which create and terminate the sandbox. Starting an already started deployment raises
+an error, so each deployment goes through exactly one start/stop lifecycle.
 
 {% include-markdown "_footer.md" %}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,4 +121,27 @@ output='' exit_code=0 failure_reason='' expect_string='SHELLPS1PREFIX' session_t
 output='test\n' exit_code=0 failure_reason='' expect_string='SHELLPS1PREFIX' session_type='bash'
 🦖 DEBUG    Ensuring deployment is stopped because object is deleted          
 ```
+
+## Running with Tenki
+
+You can also run in a [Tenki](https://tenki.cloud) sandbox by using the `TenkiDeployment`.
+Generate an API key in your Tenki workspace settings and set it as the `TENKI_API_KEY`
+environment variable (or pass it explicitly as `api_key`).
+
+```python
+from swerex.deployment.tenki import TenkiDeployment
+
+async def run_tenki_deployment():
+    deployment = TenkiDeployment(
+        startup_timeout=180,  # wait up to 3 minutes for the runtime to start
+        container_timeout=3600,  # kill the sandbox after 1 hour
+    )
+    await deployment.start()
+    await deployment.is_alive()
+    return deployment
+
+deployment = asyncio.run(run_tenki_deployment())
+asyncio.run(run_some_stuff(deployment))
+```
+
 {% include-markdown "_footer.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Docker: api/deployments/docker.md
       - Modal: api/deployments/modal.md
       - Fargate: api/deployments/fargate.md
+      - Tenki: api/deployments/tenki.md
       - Dummy: api/deployments/dummy.md
     - Runtimes classes:
       - Abstract: api/runtimes/abstract.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "swe-rex[modal]",
     "swe-rex[fargate]",
     "swe-rex[daytona]",
+    "swe-rex[tenki]",
 ]
 modal = [
     "modal>=1.0",
@@ -67,6 +68,9 @@ fargate = [
 daytona = [
     "daytona",
     "daytona-sdk >= 0.21",
+]
+tenki = [
+    "tenki-sandbox",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ daytona = [
     "daytona-sdk >= 0.21",
 ]
 tenki = [
-    "tenki-sandbox",
+    "tenki-sandbox >= 0.4.0",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ daytona = [
     "daytona-sdk >= 0.21",
 ]
 tenki = [
-    "tenki-sandbox >= 0.4.0",
+    "tenki >= 0.5.4",
 ]
 
 [tool.setuptools]

--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -253,6 +253,12 @@ class TenkiDeploymentConfig(BaseModel):
     runtime_timeout: float = Field(
         default=60.0, description="Runtime timeout (default timeout for all runtime requests)"
     )
+    runtime_retries: int = Field(
+        default=3,
+        description="How often the runtime retries requests that fail with connection errors. "
+        "Transient connection errors can occur on the preview gateway; retrying is safe because "
+        "requests carry an idempotency key.",
+    )
     sandbox_kwargs: dict[str, Any] = Field(
         default_factory=dict, description="Additional keyword arguments to pass to `tenki_sandbox.Sandbox.create`"
     )

--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -255,9 +255,10 @@ class TenkiDeploymentConfig(BaseModel):
     )
     runtime_retries: int = Field(
         default=3,
-        description="How often the runtime retries requests that fail with connection errors. "
+        description="How often the runtime retries requests that fail with transient network errors. "
         "Transient connection errors can occur on the preview gateway; retrying is safe because "
-        "requests carry an idempotency key.",
+        "requests carry an idempotency key that the server uses to deduplicate in-flight and "
+        "completed requests.",
     )
     sandbox_kwargs: dict[str, Any] = Field(
         default_factory=dict, description="Additional keyword arguments to pass to `tenki_sandbox.Sandbox.create`"

--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -211,6 +211,63 @@ class DaytonaDeploymentConfig(BaseModel):
         return DaytonaDeployment.from_config(self)
 
 
+class TenkiDeploymentConfig(BaseModel):
+    """Configuration for running in a Tenki sandbox (https://tenki.cloud)."""
+
+    api_key: str = Field(
+        default="",
+        description="Tenki API key. Falls back to the TENKI_AUTH_TOKEN/TENKI_API_KEY environment variables if empty.",
+    )
+    base_url: str = Field(
+        default="",
+        description="Tenki API base URL. Falls back to the TENKI_API_ENDPOINT environment variable or https://api.tenki.cloud if empty.",
+    )
+    project_id: str = Field(
+        default="",
+        description="Tenki project to create the sandbox in. If empty, the project is resolved automatically (only possible if the API key has access to exactly one project).",
+    )
+    workspace_id: str = Field(
+        default="",
+        description="Tenki workspace to create the sandbox in. Usually not needed, as the workspace is implied by the project.",
+    )
+    image: str | None = Field(
+        default=None, description="Image to use for the sandbox. Uses the Tenki service default if None."
+    )
+    snapshot_id: str | None = Field(
+        default=None, description="Tenki snapshot to restore the sandbox from (alternative to image)."
+    )
+    cpu_cores: int | None = Field(
+        default=None, description="Number of CPU cores for the sandbox. Uses the Tenki service default if None."
+    )
+    memory_mb: int | None = Field(
+        default=None, description="Memory in MB for the sandbox. Uses the Tenki service default if None."
+    )
+    disk_size_gb: int | None = Field(
+        default=None, description="Disk size in GB for the sandbox. Uses the Tenki service default if None."
+    )
+    port: int = Field(default=8000, description="Port to expose for the SWE Rex server")
+    container_timeout: float = Field(
+        default=60 * 15, description="Timeout for the sandbox (also used as its max duration)"
+    )
+    startup_timeout: float = Field(default=180.0, description="The time to wait for the runtime to start")
+    runtime_timeout: float = Field(
+        default=60.0, description="Runtime timeout (default timeout for all runtime requests)"
+    )
+    sandbox_kwargs: dict[str, Any] = Field(
+        default_factory=dict, description="Additional keyword arguments to pass to `tenki_sandbox.Sandbox.create`"
+    )
+
+    type: Literal["tenki"] = "tenki"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.tenki import TenkiDeployment
+
+        return TenkiDeployment.from_config(self)
+
+
 DeploymentConfig = (
     LocalDeploymentConfig
     | DockerDeploymentConfig
@@ -219,6 +276,7 @@ DeploymentConfig = (
     | RemoteDeploymentConfig
     | DummyDeploymentConfig
     | DaytonaDeploymentConfig
+    | TenkiDeploymentConfig
 )
 """Union of all deployment configurations. Useful for type hints."""
 

--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -222,13 +222,9 @@ class TenkiDeploymentConfig(BaseModel):
         default="",
         description="Tenki API base URL. Falls back to the TENKI_API_ENDPOINT environment variable or https://api.tenki.cloud if empty.",
     )
-    project_id: str = Field(
-        default="",
-        description="Tenki project to create the sandbox in. If empty, the project is resolved automatically (only possible if the API key has access to exactly one project).",
-    )
     workspace_id: str = Field(
         default="",
-        description="Tenki workspace to create the sandbox in. Usually not needed, as the workspace is implied by the project.",
+        description="Tenki workspace to create the sandbox in. Usually not needed, as the API key determines the workspace automatically.",
     )
     image: str | None = Field(
         default=None, description="Image to use for the sandbox. Uses the Tenki service default if None."
@@ -261,7 +257,7 @@ class TenkiDeploymentConfig(BaseModel):
         "completed requests.",
     )
     sandbox_kwargs: dict[str, Any] = Field(
-        default_factory=dict, description="Additional keyword arguments to pass to `tenki_sandbox.Sandbox.create`"
+        default_factory=dict, description="Additional keyword arguments to pass to `tenki.Sandbox.create`"
     )
 
     type: Literal["tenki"] = "tenki"

--- a/src/swerex/deployment/tenki.py
+++ b/src/swerex/deployment/tenki.py
@@ -119,8 +119,39 @@ class TenkiDeployment(AbstractDeployment):
         """Wait until the runtime is alive."""
         return await _wait_until_alive(self.is_alive, timeout=timeout, function_timeout=self._config.runtime_timeout)
 
+    def _read_server_log(self) -> str:
+        """Best-effort read of the server log in the sandbox (for error messages)."""
+        if self._sandbox is None:
+            return "<no sandbox>"
+        try:
+            result = self._sandbox.exec("bash", "-lc", "tail -c 4096 /tmp/swerex.log")
+            return result.stdout_text.strip() or "<empty>"
+        except Exception as e:
+            return f"<could not read /tmp/swerex.log: {e}>"
+
+    def _terminate_sandbox(self):
+        """Terminates the sandbox (if any).
+
+        The sandbox handle is only cleared if termination succeeds, so that a
+        failed `stop()` can be retried.
+        """
+        if self._sandbox is None:
+            return
+        self.logger.info(f"Terminating Tenki sandbox with ID: {self._sandbox_id}")
+        self._sandbox.close_if_open()
+        self.logger.info("Tenki sandbox terminated successfully")
+        self._sandbox = None
+        self._sandbox_id = None
+
     async def start(self):
-        """Starts the runtime in a Tenki sandbox."""
+        """Starts the runtime in a Tenki sandbox.
+
+        Raises:
+            RuntimeError: If the deployment is already started or the runtime fails to start.
+        """
+        if self._sandbox is not None:
+            msg = "The deployment is already started. Call stop() before starting it again."
+            raise RuntimeError(msg)
         self.logger.info("Creating Tenki sandbox...")
 
         create_kwargs: dict[str, Any] = {
@@ -153,53 +184,70 @@ class TenkiDeployment(AbstractDeployment):
         self._sandbox_id = self._sandbox.id
         self.logger.info(f"Created Tenki sandbox with ID: {self._sandbox_id}")
 
-        self._auth_token = self._get_token()
+        try:
+            self._auth_token = self._get_token()
 
-        command = self._get_command(token=self._auth_token)
-        self.logger.info("Starting SWE Rex server in Tenki sandbox...")
-        result = self._sandbox.exec("bash", "-lc", command)
-        if result.exit_code != 0:
-            self.logger.error(f"Failed to start SWE Rex server: {result.stderr_text}")
-            await self.stop()
-            msg = f"Failed to start SWE Rex server: {result.stderr_text}"
-            raise RuntimeError(msg)
+            command = self._get_command(token=self._auth_token)
+            self.logger.info("Starting SWE Rex server in Tenki sandbox...")
+            result = self._sandbox.exec("bash", "-lc", command)
+            if result.exit_code != 0:
+                # The server itself is backgrounded, so this only catches failures
+                # of the launcher; server failures surface via the timeout below.
+                msg = f"Failed to launch the SWE Rex server: {result.stderr_text}"
+                raise RuntimeError(msg)
 
-        preview = self._sandbox.expose_port(self._config.port, ttl=self._config.container_timeout)
+            preview = self._sandbox.expose_port(self._config.port, ttl=self._config.container_timeout)
 
-        self._runtime = RemoteRuntime(
-            host=preview.url,
-            port=None,
-            auth_token=self._auth_token,
-            timeout=self._config.runtime_timeout,
-            num_retries=self._config.runtime_retries,
-            logger=self.logger,
-        )
+            self._runtime = RemoteRuntime(
+                host=preview.url,
+                port=None,
+                auth_token=self._auth_token,
+                timeout=self._config.runtime_timeout,
+                num_retries=self._config.runtime_retries,
+                logger=self.logger,
+            )
 
-        t0 = time.time()
-        await self._wait_until_alive(timeout=self._config.startup_timeout)
-        self.logger.info(f"Runtime started in {time.time() - t0:.2f}s")
+            t0 = time.time()
+            try:
+                await self._wait_until_alive(timeout=self._config.startup_timeout)
+            except Exception as e:
+                msg = (
+                    f"The SWE Rex server did not start within {self._config.startup_timeout}s. "
+                    f"Server log (/tmp/swerex.log in the sandbox):\n{self._read_server_log()}"
+                )
+                raise RuntimeError(msg) from e
+            self.logger.info(f"Runtime started in {time.time() - t0:.2f}s")
+        except BaseException:
+            # Don't leave the sandbox running (and billing) if startup fails
+            # or is cancelled.
+            self._runtime = None
+            self._auth_token = None
+            try:
+                self._terminate_sandbox()
+            except Exception as cleanup_exc:
+                self.logger.error(f"Failed to terminate Tenki sandbox after failed startup: {cleanup_exc}")
+            raise
 
     async def stop(self):
-        """Stops the runtime and terminates the Tenki sandbox."""
-        if self._runtime is not None:
-            try:
-                await self._runtime.close()
-            except Exception as e:
-                # Closing the runtime must not prevent the sandbox from being terminated
-                self.logger.error(f"Failed to close runtime: {e}")
-            self._runtime = None
+        """Stops the runtime and terminates the Tenki sandbox.
 
-        if self._sandbox is not None:
-            try:
-                self.logger.info(f"Terminating Tenki sandbox with ID: {self._sandbox_id}")
-                self._sandbox.close_if_open()
-                self.logger.info("Tenki sandbox terminated successfully")
-            except Exception as e:
-                self.logger.error(f"Failed to terminate Tenki sandbox: {e}")
-
-        self._sandbox = None
-        self._sandbox_id = None
-        self._auth_token = None
+        Sandbox termination errors are raised (with the sandbox handle kept),
+        so that a failed `stop()` can be retried.
+        """
+        try:
+            if self._runtime is not None:
+                try:
+                    await self._runtime.close()
+                except Exception as e:
+                    # Closing the runtime must not prevent the sandbox from being terminated
+                    self.logger.error(f"Failed to close runtime: {e}")
+                finally:
+                    self._runtime = None
+        finally:
+            # Terminate the sandbox even if closing the runtime was cancelled.
+            # The SDK call is synchronous, so cancellation cannot interrupt it.
+            self._auth_token = None
+            self._terminate_sandbox()
 
     @property
     def runtime(self) -> RemoteRuntime:

--- a/src/swerex/deployment/tenki.py
+++ b/src/swerex/deployment/tenki.py
@@ -171,6 +171,7 @@ class TenkiDeployment(AbstractDeployment):
             port=None,
             auth_token=self._auth_token,
             timeout=self._config.runtime_timeout,
+            num_retries=self._config.runtime_retries,
             logger=self.logger,
         )
 
@@ -181,7 +182,11 @@ class TenkiDeployment(AbstractDeployment):
     async def stop(self):
         """Stops the runtime and terminates the Tenki sandbox."""
         if self._runtime is not None:
-            await self._runtime.close()
+            try:
+                await self._runtime.close()
+            except Exception as e:
+                # Closing the runtime must not prevent the sandbox from being terminated
+                self.logger.error(f"Failed to close runtime: {e}")
             self._runtime = None
 
         if self._sandbox is not None:

--- a/src/swerex/deployment/tenki.py
+++ b/src/swerex/deployment/tenki.py
@@ -3,7 +3,7 @@ import time
 import uuid
 from typing import Any
 
-from tenki_sandbox import Client, Sandbox
+from tenki import Sandbox
 from typing_extensions import Self
 
 from swerex import PACKAGE_NAME, REMOTE_EXECUTABLE_NAME
@@ -51,23 +51,6 @@ class TenkiDeployment(AbstractDeployment):
         if self._config.base_url:
             client_kwargs["base_url"] = self._config.base_url
         return client_kwargs
-
-    def _resolve_project_id(self) -> str:
-        """Resolve the project to create the sandbox in from the API key's identity.
-
-        Raises:
-            RuntimeError: If the API key has access to more than one project.
-        """
-        client = Client(**self._get_client_kwargs())
-        identity = client.who_am_i()
-        projects = [project.id for workspace in identity.workspaces for project in workspace.projects]
-        if len(projects) != 1:
-            msg = (
-                f"Could not resolve the Tenki project automatically (found {len(projects)} projects). "
-                "Please set project_id in the deployment configuration."
-            )
-            raise RuntimeError(msg)
-        return projects[0]
 
     def _get_command(self, *, token: str) -> str:
         """Generate the command to run the SWE Rex server."""
@@ -157,7 +140,6 @@ class TenkiDeployment(AbstractDeployment):
 
         create_kwargs: dict[str, Any] = {
             "name": f"swe-rex-{uuid.uuid4().hex[:8]}",
-            "project_id": self._config.project_id or self._resolve_project_id(),
             # Inbound is required to expose the server port, outbound for the
             # pipx fallback installation of swe-rex.
             "allow_inbound": True,

--- a/src/swerex/deployment/tenki.py
+++ b/src/swerex/deployment/tenki.py
@@ -1,0 +1,208 @@
+import logging
+import time
+import uuid
+from typing import Any
+
+from tenki_sandbox import Client, Sandbox
+from typing_extensions import Self
+
+from swerex import PACKAGE_NAME, REMOTE_EXECUTABLE_NAME
+from swerex.deployment.abstract import AbstractDeployment
+from swerex.deployment.config import TenkiDeploymentConfig
+from swerex.deployment.hooks.abstract import CombinedDeploymentHook, DeploymentHook
+from swerex.exceptions import DeploymentNotStartedError
+from swerex.runtime.abstract import IsAliveResponse
+from swerex.runtime.remote import RemoteRuntime
+from swerex.utils.log import get_logger
+from swerex.utils.wait import _wait_until_alive
+
+__all__ = ["TenkiDeployment", "TenkiDeploymentConfig"]
+
+
+class TenkiDeployment(AbstractDeployment):
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger | None = None,
+        **kwargs: Any,
+    ):
+        """Deployment for running the SWE-ReX server in a Tenki sandbox (https://tenki.cloud).
+
+        Args:
+            **kwargs: Keyword arguments (see `TenkiDeploymentConfig` for details).
+        """
+        self._config = TenkiDeploymentConfig(**kwargs)
+        self._runtime: RemoteRuntime | None = None
+        self._sandbox: Sandbox | None = None
+        self._sandbox_id = None
+        self._auth_token = None
+        self.logger = logger or get_logger("rex-deploy")
+        self._hooks = CombinedDeploymentHook()
+
+    def add_hook(self, hook: DeploymentHook):
+        self._hooks.add_hook(hook)
+
+    @classmethod
+    def from_config(cls, config: TenkiDeploymentConfig) -> Self:
+        return cls(**config.model_dump())
+
+    def _get_token(self) -> str:
+        """Generate a unique authentication token."""
+        return str(uuid.uuid4())
+
+    def _get_client_kwargs(self) -> dict[str, Any]:
+        client_kwargs: dict[str, Any] = {}
+        if self._config.api_key:
+            client_kwargs["auth_token"] = self._config.api_key
+        if self._config.base_url:
+            client_kwargs["base_url"] = self._config.base_url
+        return client_kwargs
+
+    def _resolve_project_id(self) -> str:
+        """Resolve the project to create the sandbox in from the API key's identity.
+
+        Raises:
+            RuntimeError: If the API key has access to more than one project.
+        """
+        client = Client(**self._get_client_kwargs())
+        identity = client.who_am_i()
+        projects = [project.id for workspace in identity.workspaces for project in workspace.projects]
+        if len(projects) != 1:
+            msg = (
+                f"Could not resolve the Tenki project automatically (found {len(projects)} projects). "
+                "Please set project_id in the deployment configuration."
+            )
+            raise RuntimeError(msg)
+        return projects[0]
+
+    def _get_command(self, *, token: str) -> str:
+        """Generate the command to run the SWE Rex server."""
+        main_command = f"{REMOTE_EXECUTABLE_NAME} --port {self._config.port} --auth-token {token}"
+        fallback_commands = [
+            # The default Tenki image runs as a non-root user with passwordless sudo
+            "SUDO=; if [ $(id -u) -ne 0 ] && command -v sudo > /dev/null; then SUDO=sudo; fi",
+            "$SUDO apt-get update -y",
+            "$SUDO apt-get install pipx -y",
+            "pipx ensurepath",
+            f"pipx run {PACKAGE_NAME} --port {self._config.port} --auth-token {token}",
+        ]
+        fallback_script = " && ".join(fallback_commands)
+        inner_command = f"{main_command} || ( {fallback_script} )"
+        # `exec` streams the command's output until it closes, so the server is
+        # backgrounded with its streams detached (see the Tenki docs on port exposure).
+        return (
+            f"timeout {self._config.container_timeout}s bash -c '{inner_command}' > /tmp/swerex.log 2>&1 < /dev/null &"
+        )
+
+    async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
+        """Checks if the runtime is alive.
+
+        Raises:
+            DeploymentNotStartedError: If the deployment was not started.
+        """
+        if self._runtime is None or self._sandbox is None:
+            raise DeploymentNotStartedError()
+
+        try:
+            self._sandbox.refresh()
+            state = self._sandbox.state
+        except Exception as e:
+            msg = f"Error checking Tenki sandbox status: {e}"
+            raise RuntimeError(msg)
+        if state != "RUNNING":
+            msg = f"Tenki sandbox is not running (state: {state})"
+            raise RuntimeError(msg)
+
+        return await self._runtime.is_alive(timeout=timeout)
+
+    async def _wait_until_alive(self, timeout: float):
+        """Wait until the runtime is alive."""
+        return await _wait_until_alive(self.is_alive, timeout=timeout, function_timeout=self._config.runtime_timeout)
+
+    async def start(self):
+        """Starts the runtime in a Tenki sandbox."""
+        self.logger.info("Creating Tenki sandbox...")
+
+        create_kwargs: dict[str, Any] = {
+            "name": f"swe-rex-{uuid.uuid4().hex[:8]}",
+            "project_id": self._config.project_id or self._resolve_project_id(),
+            # Inbound is required to expose the server port, outbound for the
+            # pipx fallback installation of swe-rex.
+            "allow_inbound": True,
+            "allow_outbound": True,
+            # Kill switch so that a forgotten sandbox doesn't run forever.
+            "max_duration": self._config.container_timeout,
+        }
+        create_kwargs.update(self._get_client_kwargs())
+        if self._config.workspace_id:
+            create_kwargs["workspace_id"] = self._config.workspace_id
+        if self._config.image is not None:
+            create_kwargs["image"] = self._config.image
+        if self._config.snapshot_id is not None:
+            create_kwargs["snapshot_id"] = self._config.snapshot_id
+        if self._config.cpu_cores is not None:
+            create_kwargs["cpu_cores"] = self._config.cpu_cores
+        if self._config.memory_mb is not None:
+            create_kwargs["memory_mb"] = self._config.memory_mb
+        if self._config.disk_size_gb is not None:
+            create_kwargs["disk_size_gb"] = self._config.disk_size_gb
+        create_kwargs.update(self._config.sandbox_kwargs)
+
+        # Waits until the sandbox is RUNNING and exec-ready
+        self._sandbox = Sandbox.create(**create_kwargs)
+        self._sandbox_id = self._sandbox.id
+        self.logger.info(f"Created Tenki sandbox with ID: {self._sandbox_id}")
+
+        self._auth_token = self._get_token()
+
+        command = self._get_command(token=self._auth_token)
+        self.logger.info("Starting SWE Rex server in Tenki sandbox...")
+        result = self._sandbox.exec("bash", "-lc", command)
+        if result.exit_code != 0:
+            self.logger.error(f"Failed to start SWE Rex server: {result.stderr_text}")
+            await self.stop()
+            msg = f"Failed to start SWE Rex server: {result.stderr_text}"
+            raise RuntimeError(msg)
+
+        preview = self._sandbox.expose_port(self._config.port, ttl=self._config.container_timeout)
+
+        self._runtime = RemoteRuntime(
+            host=preview.url,
+            port=None,
+            auth_token=self._auth_token,
+            timeout=self._config.runtime_timeout,
+            logger=self.logger,
+        )
+
+        t0 = time.time()
+        await self._wait_until_alive(timeout=self._config.startup_timeout)
+        self.logger.info(f"Runtime started in {time.time() - t0:.2f}s")
+
+    async def stop(self):
+        """Stops the runtime and terminates the Tenki sandbox."""
+        if self._runtime is not None:
+            await self._runtime.close()
+            self._runtime = None
+
+        if self._sandbox is not None:
+            try:
+                self.logger.info(f"Terminating Tenki sandbox with ID: {self._sandbox_id}")
+                self._sandbox.close_if_open()
+                self.logger.info("Tenki sandbox terminated successfully")
+            except Exception as e:
+                self.logger.error(f"Failed to terminate Tenki sandbox: {e}")
+
+        self._sandbox = None
+        self._sandbox_id = None
+        self._auth_token = None
+
+    @property
+    def runtime(self) -> RemoteRuntime:
+        """Returns the runtime if running.
+
+        Raises:
+            DeploymentNotStartedError: If the deployment was not started.
+        """
+        if self._runtime is None:
+            raise DeploymentNotStartedError()
+        return self._runtime

--- a/src/swerex/deployment/tenki.py
+++ b/src/swerex/deployment/tenki.py
@@ -34,8 +34,6 @@ class TenkiDeployment(AbstractDeployment):
         self._config = TenkiDeploymentConfig(**kwargs)
         self._runtime: RemoteRuntime | None = None
         self._sandbox: Sandbox | None = None
-        self._sandbox_id = None
-        self._auth_token = None
         self.logger = logger or get_logger("rex-deploy")
         self._hooks = CombinedDeploymentHook()
 
@@ -45,10 +43,6 @@ class TenkiDeployment(AbstractDeployment):
     @classmethod
     def from_config(cls, config: TenkiDeploymentConfig) -> Self:
         return cls(**config.model_dump())
-
-    def _get_token(self) -> str:
-        """Generate a unique authentication token."""
-        return str(uuid.uuid4())
 
     def _get_client_kwargs(self) -> dict[str, Any]:
         client_kwargs: dict[str, Any] = {}
@@ -116,8 +110,16 @@ class TenkiDeployment(AbstractDeployment):
         return await self._runtime.is_alive(timeout=timeout)
 
     async def _wait_until_alive(self, timeout: float):
-        """Wait until the runtime is alive."""
-        return await _wait_until_alive(self.is_alive, timeout=timeout, function_timeout=self._config.runtime_timeout)
+        """Wait until the runtime is alive.
+
+        Only polls the runtime endpoint: going through `is_alive` would add a
+        Tenki control-plane round-trip to every 0.25s poll iteration.
+        """
+        if self._runtime is None:
+            raise DeploymentNotStartedError()
+        return await _wait_until_alive(
+            self._runtime.is_alive, timeout=timeout, function_timeout=self._config.runtime_timeout
+        )
 
     def _read_server_log(self) -> str:
         """Best-effort read of the server log in the sandbox (for error messages)."""
@@ -137,11 +139,10 @@ class TenkiDeployment(AbstractDeployment):
         """
         if self._sandbox is None:
             return
-        self.logger.info(f"Terminating Tenki sandbox with ID: {self._sandbox_id}")
+        self.logger.info(f"Terminating Tenki sandbox with ID: {self._sandbox.id}")
         self._sandbox.close_if_open()
         self.logger.info("Tenki sandbox terminated successfully")
         self._sandbox = None
-        self._sandbox_id = None
 
     async def start(self):
         """Starts the runtime in a Tenki sandbox.
@@ -181,13 +182,11 @@ class TenkiDeployment(AbstractDeployment):
 
         # Waits until the sandbox is RUNNING and exec-ready
         self._sandbox = Sandbox.create(**create_kwargs)
-        self._sandbox_id = self._sandbox.id
-        self.logger.info(f"Created Tenki sandbox with ID: {self._sandbox_id}")
+        self.logger.info(f"Created Tenki sandbox with ID: {self._sandbox.id}")
 
         try:
-            self._auth_token = self._get_token()
-
-            command = self._get_command(token=self._auth_token)
+            auth_token = str(uuid.uuid4())
+            command = self._get_command(token=auth_token)
             self.logger.info("Starting SWE Rex server in Tenki sandbox...")
             result = self._sandbox.exec("bash", "-lc", command)
             if result.exit_code != 0:
@@ -201,7 +200,7 @@ class TenkiDeployment(AbstractDeployment):
             self._runtime = RemoteRuntime(
                 host=preview.url,
                 port=None,
-                auth_token=self._auth_token,
+                auth_token=auth_token,
                 timeout=self._config.runtime_timeout,
                 num_retries=self._config.runtime_retries,
                 logger=self.logger,
@@ -221,7 +220,6 @@ class TenkiDeployment(AbstractDeployment):
             # Don't leave the sandbox running (and billing) if startup fails
             # or is cancelled.
             self._runtime = None
-            self._auth_token = None
             try:
                 self._terminate_sandbox()
             except Exception as cleanup_exc:
@@ -246,7 +244,6 @@ class TenkiDeployment(AbstractDeployment):
         finally:
             # Terminate the sandbox even if closing the runtime was cancelled.
             # The SDK call is synchronous, so cancellation cannot interrupt it.
-            self._auth_token = None
             self._terminate_sandbox()
 
     @property

--- a/src/swerex/runtime/config.py
+++ b/src/swerex/runtime/config.py
@@ -29,9 +29,11 @@ class RemoteRuntimeConfig(BaseModel):
     timeout: float = 0.15
     """The timeout for the runtime."""
     num_retries: int = 0
-    """How often to retry requests that fail with connection errors.
-    Retries reuse the same idempotency key (`X-Request-ID` header), so the server
-    will not execute a request twice if it already processed it.
+    """How often to retry requests that fail with transient network errors.
+    Retries reuse the same idempotency key (`X-Request-ID` header), which the
+    server uses to deduplicate both in-flight and completed requests, so a
+    retried request is never executed twice. Exceptions raised by the request
+    itself on the server are never retried.
     This is useful for deployments that connect through the public internet
     (e.g., cloud sandboxes), where transient connection errors can occur.
     """

--- a/src/swerex/runtime/config.py
+++ b/src/swerex/runtime/config.py
@@ -28,6 +28,13 @@ class RemoteRuntimeConfig(BaseModel):
     """The port to connect to."""
     timeout: float = 0.15
     """The timeout for the runtime."""
+    num_retries: int = 0
+    """How often to retry requests that fail with connection errors.
+    Retries reuse the same idempotency key (`X-Request-ID` header), so the server
+    will not execute a request twice if it already processed it.
+    This is useful for deployments that connect through the public internet
+    (e.g., cloud sandboxes), where transient connection errors can occur.
+    """
 
     type: Literal["remote"] = "remote"
     """Discriminator for (de)serialization/CLI. Do not change."""

--- a/src/swerex/runtime/remote.py
+++ b/src/swerex/runtime/remote.py
@@ -45,6 +45,10 @@ _RETRYABLE_EXCEPTIONS = (aiohttp.ClientError, asyncio.TimeoutError, ConnectionEr
 retried requests by their `X-Request-ID` header, so a request that did reach
 the server is never executed twice."""
 
+_RETRYABLE_STATUSES = (502, 503, 504)
+"""Gateway errors: the request may never have reached the server, and the
+`X-Request-ID` deduplication makes retrying safe if it did."""
+
 
 class RemoteRuntime(AbstractRuntime):
     def __init__(
@@ -117,9 +121,6 @@ class RemoteRuntime(AbstractRuntime):
             )
             exception = SwerexException(exc_transfer.message)
         exception.extra_info = exc_transfer.extra_info
-        # The request was executed on the server, so it must never be retried,
-        # even if the transferred exception happens to be a connection error class.
-        exception._swerex_transferred = True
         raise exception from None
 
     async def _handle_response_errors(self, response: aiohttp.ClientResponse) -> None:
@@ -170,49 +171,45 @@ class RemoteRuntime(AbstractRuntime):
     async def wait_until_alive(self, *, timeout: float = 60.0):
         return await _wait_until_alive(self.is_alive, timeout=timeout)
 
-    async def _request(
-        self, endpoint: str, payload: BaseModel | None, output_class: Any, num_retries: int | None = None
-    ):
+    async def _request(self, endpoint: str, payload: BaseModel | None, output_class: Any):
         """Small helper to make requests to the server and handle errors and output."""
-        if num_retries is None:
-            num_retries = self._config.num_retries
         request_url = f"{self._api_url}/{endpoint}"
         request_id = str(uuid.uuid4())
         headers = self._headers.copy()
         headers["X-Request-ID"] = request_id  # idempotency key for the request
 
-        retry_count = 0
-        last_exception: Exception | None = None
+        num_retries = self._config.num_retries
         retry_delay = 0.1
         backoff_max = 5
 
-        while retry_count <= num_retries:
-            try:
-                async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(force_close=True)) as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(force_close=True)) as session:
+            for attempt in range(num_retries + 1):
+                try:
                     async with session.post(
                         request_url,
                         json=payload.model_dump() if payload else None,
                         headers=headers,
                     ) as resp:
-                        await self._handle_response_errors(resp)
-                        return output_class(**await resp.json())
-            except SwerexException:
-                # Exceptions transferred from the server (e.g., a failing command)
-                # are not connection issues, so retrying would not help
-                raise
-            except _RETRYABLE_EXCEPTIONS as e:
-                if getattr(e, "_swerex_transferred", False):
-                    raise
-                last_exception = e
-                retry_count += 1
-                if retry_count <= num_retries:
+                        if resp.status in _RETRYABLE_STATUSES:
+                            resp.raise_for_status()
+                        data = await resp.json()
+                    break
+                except _RETRYABLE_EXCEPTIONS as e:
+                    if attempt >= num_retries:
+                        self.logger.error("Error making request %s after %d retries: %s", request_id, num_retries, e)
+                        raise
                     await asyncio.sleep(retry_delay)
-                    retry_delay *= 2
-                    retry_delay += random.uniform(0, 0.5)
-                    retry_delay = min(retry_delay, backoff_max)
-                    continue
-                self.logger.error("Error making request %s after %d retries: %s", request_id, num_retries, e)
-        raise last_exception  # type: ignore
+                    retry_delay = min(retry_delay * 2 + random.uniform(0, 0.5), backoff_max)
+
+            # The server produced this response, so nothing below is retried:
+            # server-side errors (e.g., a failing command) are not connection issues.
+            if resp.status == 511:
+                exc_transfer = _ExceptionTransfer(**data["swerexception"])
+                self._handle_transfer_exception(exc_transfer)
+            if resp.status >= 400:
+                self.logger.critical("Received error response: %s", data)
+                resp.raise_for_status()
+            return output_class(**data)
 
     async def create_session(self, request: CreateSessionRequest) -> CreateSessionResponse:
         """Creates a new session."""

--- a/src/swerex/runtime/remote.py
+++ b/src/swerex/runtime/remote.py
@@ -40,6 +40,11 @@ from swerex.utils.wait import _wait_until_alive
 
 __all__ = ["RemoteRuntime", "RemoteRuntimeConfig"]
 
+_RETRYABLE_EXCEPTIONS = (aiohttp.ClientError, asyncio.TimeoutError, ConnectionError)
+"""Transient network errors that are safe to retry: the server deduplicates
+retried requests by their `X-Request-ID` header, so a request that did reach
+the server is never executed twice."""
+
 
 class RemoteRuntime(AbstractRuntime):
     def __init__(
@@ -112,6 +117,9 @@ class RemoteRuntime(AbstractRuntime):
             )
             exception = SwerexException(exc_transfer.message)
         exception.extra_info = exc_transfer.extra_info
+        # The request was executed on the server, so it must never be retried,
+        # even if the transferred exception happens to be a connection error class.
+        exception._swerex_transferred = True
         raise exception from None
 
     async def _handle_response_errors(self, response: aiohttp.ClientResponse) -> None:
@@ -192,7 +200,9 @@ class RemoteRuntime(AbstractRuntime):
                 # Exceptions transferred from the server (e.g., a failing command)
                 # are not connection issues, so retrying would not help
                 raise
-            except Exception as e:
+            except _RETRYABLE_EXCEPTIONS as e:
+                if getattr(e, "_swerex_transferred", False):
+                    raise
                 last_exception = e
                 retry_count += 1
                 if retry_count <= num_retries:

--- a/src/swerex/runtime/remote.py
+++ b/src/swerex/runtime/remote.py
@@ -162,8 +162,12 @@ class RemoteRuntime(AbstractRuntime):
     async def wait_until_alive(self, *, timeout: float = 60.0):
         return await _wait_until_alive(self.is_alive, timeout=timeout)
 
-    async def _request(self, endpoint: str, payload: BaseModel | None, output_class: Any, num_retries: int = 0):
+    async def _request(
+        self, endpoint: str, payload: BaseModel | None, output_class: Any, num_retries: int | None = None
+    ):
         """Small helper to make requests to the server and handle errors and output."""
+        if num_retries is None:
+            num_retries = self._config.num_retries
         request_url = f"{self._api_url}/{endpoint}"
         request_id = str(uuid.uuid4())
         headers = self._headers.copy()
@@ -184,6 +188,10 @@ class RemoteRuntime(AbstractRuntime):
                     ) as resp:
                         await self._handle_response_errors(resp)
                         return output_class(**await resp.json())
+            except SwerexException:
+                # Exceptions transferred from the server (e.g., a failing command)
+                # are not connection issues, so retrying would not help
+                raise
             except Exception as e:
                 last_exception = e
                 retry_count += 1

--- a/src/swerex/server.py
+++ b/src/swerex/server.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 import argparse
+import asyncio
 import shutil
 import tempfile
 import traceback
 import zipfile
+from collections import OrderedDict
 from pathlib import Path
 
 from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
@@ -40,25 +42,44 @@ def serialize_model(model):
 
 
 class ResponseManager:
+    """Deduplicates requests by their idempotency key (`X-Request-ID` header)
+    so that client retries never execute a request twice.
+
+    Responses of completed requests are kept in a bounded LRU cache. Requests
+    that are still executing are tracked separately, so that a duplicate
+    arriving while the original is in flight waits for the original's response
+    instead of executing the request again.
     """
-    This stores the response of the last request, and is used in retries to return
-    already executed requests.
 
-    Note that in the case of multiple concurrent clients, idempotency isn't guaranteed.
-    """
+    def __init__(self, max_entries: int = 256):
+        self._max_entries = max_entries
+        self._completed: OrderedDict[str, Response] = OrderedDict()
+        self._in_flight: dict[str, asyncio.Future] = {}
 
-    def __init__(self):
-        self.last_processed_request_id = None
-        self.last_processed_response = None
+    def get_completed(self, request_id: str) -> Response | None:
+        response = self._completed.get(request_id)
+        if response is not None:
+            self._completed.move_to_end(request_id)
+        return response
 
-    def get_response(self, request_id):
-        if request_id == self.last_processed_request_id:
-            return self.last_processed_response
-        return None
+    def get_in_flight(self, request_id: str) -> "asyncio.Future | None":
+        return self._in_flight.get(request_id)
 
-    def set_response(self, request_id, response):
-        self.last_processed_request_id = request_id
-        self.last_processed_response = response
+    def start(self, request_id: str) -> None:
+        self._in_flight[request_id] = asyncio.get_running_loop().create_future()
+
+    def finish(self, request_id: str, response: Response) -> None:
+        self._completed[request_id] = response
+        while len(self._completed) > self._max_entries:
+            self._completed.popitem(last=False)
+        self._in_flight.pop(request_id).set_result(response)
+
+    def fail(self, request_id: str, exc: BaseException) -> None:
+        future = self._in_flight.pop(request_id)
+        future.set_exception(exc)
+        # Mark the exception as retrieved so that a duplicate-free failure
+        # doesn't emit an "exception was never retrieved" warning.
+        future.exception()
 
 
 response_manager = ResponseManager()
@@ -78,27 +99,39 @@ async def authenticate(request: Request, call_next):
 async def handle_request_id(request: Request, call_next):
     """Handle request ID for idempotency."""
     request_id = request.headers.get("X-Request-ID")
-    if request_id:
-        response = response_manager.get_response(request_id)
-        if response:
-            return response
+    if not request_id:
+        return await call_next(request)
 
-    response = await call_next(request)
+    cached = response_manager.get_completed(request_id)
+    if cached is not None:
+        return cached
 
-    body_content = b""
-    async for chunk in response.body_iterator:
-        body_content += chunk
+    in_flight = response_manager.get_in_flight(request_id)
+    if in_flight is not None:
+        # A duplicate of a request that is still executing (e.g., the client
+        # timed out and retried): wait for the original instead of executing
+        # the request a second time. Shielded so that the duplicate's
+        # disconnect cannot cancel the shared future.
+        return await asyncio.shield(in_flight)
 
-    new_response = Response(
-        content=body_content,
-        status_code=response.status_code,
-        headers=dict(response.headers),
-        media_type=response.media_type,
-    )
-
-    if request_id:
-        response_manager.set_response(request_id, new_response)
-
+    response_manager.start(request_id)
+    try:
+        response = await call_next(request)
+        body_content = b""
+        async for chunk in response.body_iterator:
+            body_content += chunk
+        new_response = Response(
+            content=body_content,
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            media_type=response.media_type,
+        )
+    except BaseException as exc:
+        # Failed executions are not cached: any waiting duplicate fails too,
+        # and a later retry executes the request again.
+        response_manager.fail(request_id, exc)
+        raise
+    response_manager.finish(request_id, new_response)
     return new_response
 
 

--- a/src/swerex/server.py
+++ b/src/swerex/server.py
@@ -62,7 +62,7 @@ class ResponseManager:
             self._completed.move_to_end(request_id)
         return response
 
-    def get_in_flight(self, request_id: str) -> "asyncio.Future | None":
+    def get_in_flight(self, request_id: str) -> asyncio.Future | None:
         return self._in_flight.get(request_id)
 
     def start(self, request_id: str) -> None:
@@ -70,7 +70,7 @@ class ResponseManager:
 
     def finish(self, request_id: str, response: Response) -> None:
         self._completed[request_id] = response
-        while len(self._completed) > self._max_entries:
+        if len(self._completed) > self._max_entries:
             self._completed.popitem(last=False)
         self._in_flight.pop(request_id).set_result(response)
 

--- a/tests/test_get_deployment.py
+++ b/tests/test_get_deployment.py
@@ -8,6 +8,7 @@ from swerex.deployment.config import (
     LocalDeploymentConfig,
     ModalDeploymentConfig,
     RemoteDeploymentConfig,
+    TenkiDeploymentConfig,
 )
 from swerex.deployment.daytona import DaytonaDeployment
 from swerex.deployment.docker import DockerDeployment
@@ -15,6 +16,7 @@ from swerex.deployment.fargate import FargateDeployment
 from swerex.deployment.local import LocalDeployment
 from swerex.deployment.modal import ModalDeployment
 from swerex.deployment.remote import RemoteDeployment
+from swerex.deployment.tenki import TenkiDeployment
 
 
 def test_get_local_deployment():
@@ -45,6 +47,11 @@ def test_get_fargate_deployment():
 def test_get_daytona_deployment():
     deployment = get_deployment(DaytonaDeploymentConfig(image="test"))
     assert isinstance(deployment, DaytonaDeployment)
+
+
+def test_get_tenki_deployment():
+    deployment = get_deployment(TenkiDeploymentConfig(api_key="test"))
+    assert isinstance(deployment, TenkiDeployment)
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,6 @@
+import concurrent.futures
+import uuid
+
 import requests
 
 from tests.conftest import RemoteServer
@@ -33,3 +36,57 @@ def test_unauthenticated_request(remote_server: RemoteServer):
     ]:
         response = requests.get(f"http://127.0.0.1:{remote_server.port}/{endpoint}")
         assert response.status_code == 403
+
+
+def _execute_marker_command(remote_server: RemoteServer, marker_file, request_id: str, sleep: float = 0.0):
+    """POST /execute a command that appends a line to `marker_file`."""
+    command = f"sleep {sleep}; echo executed >> {marker_file}"
+    return requests.post(
+        f"http://127.0.0.1:{remote_server.port}/execute",
+        json={"command": command, "shell": True},
+        headers={**remote_server.headers, "X-Request-ID": request_id},
+    )
+
+
+def _marker_count(marker_file) -> int:
+    if not marker_file.exists():
+        return 0
+    return len(marker_file.read_text().splitlines())
+
+
+def test_request_id_replay_executes_once(remote_server: RemoteServer, tmp_path):
+    """A retried (sequential) request with the same X-Request-ID is served from cache."""
+    marker_file = tmp_path / "marker.txt"
+    request_id = str(uuid.uuid4())
+    first = _execute_marker_command(remote_server, marker_file, request_id)
+    second = _execute_marker_command(remote_server, marker_file, request_id)
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert _marker_count(marker_file) == 1
+
+
+def test_request_id_concurrent_duplicates_execute_once(remote_server: RemoteServer, tmp_path):
+    """A duplicate arriving while the original is still executing waits for it
+    instead of executing the request a second time."""
+    marker_file = tmp_path / "marker.txt"
+    request_id = str(uuid.uuid4())
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(_execute_marker_command, remote_server, marker_file, request_id, 1.0) for _ in range(2)]
+        responses = [f.result() for f in futures]
+    assert all(r.status_code == 200 for r in responses)
+    assert responses[0].json() == responses[1].json()
+    assert _marker_count(marker_file) == 1
+
+
+def test_request_id_survives_interleaved_requests(remote_server: RemoteServer, tmp_path):
+    """Requests with other IDs must not evict a cached response (no single-slot cache)."""
+    marker_file = tmp_path / "marker.txt"
+    request_id = str(uuid.uuid4())
+    _execute_marker_command(remote_server, marker_file, request_id)
+    for _ in range(5):
+        other_file = tmp_path / "other.txt"
+        _execute_marker_command(remote_server, other_file, str(uuid.uuid4()))
+    replay = _execute_marker_command(remote_server, marker_file, request_id)
+    assert replay.status_code == 200
+    assert _marker_count(marker_file) == 1

--- a/tests/test_tenki_deployment.py
+++ b/tests/test_tenki_deployment.py
@@ -16,7 +16,7 @@ class _FakeExecResult:
 
 
 def _make_fake_sandbox_class():
-    """A fresh fake `tenki_sandbox.Sandbox` class (with its own creation log) per test."""
+    """A fresh fake `tenki.Sandbox` class (with its own creation log) per test."""
 
     class FakeSandbox:
         created: list = []
@@ -72,7 +72,7 @@ def patched_wait(monkeypatch):
 
 
 def _make_deployment(**kwargs) -> TenkiDeployment:
-    config = dict(project_id="proj-test", api_key="tk_test", runtime_retries=0, runtime_timeout=0.2)
+    config = dict(api_key="tk_test", runtime_retries=0, runtime_timeout=0.2)
     config.update(kwargs)
     return TenkiDeployment(**config)
 

--- a/tests/test_tenki_deployment.py
+++ b/tests/test_tenki_deployment.py
@@ -1,9 +1,126 @@
+import asyncio
 import os
+from types import SimpleNamespace
 
 import pytest
 
 from swerex.deployment.tenki import TenkiDeployment
 from swerex.runtime.abstract import Command
+
+
+class _FakeExecResult:
+    def __init__(self, exit_code: int = 0, stdout_text: str = "", stderr_text: str = ""):
+        self.exit_code = exit_code
+        self.stdout_text = stdout_text
+        self.stderr_text = stderr_text
+
+
+def _make_fake_sandbox_class():
+    """A fresh fake `tenki_sandbox.Sandbox` class (with its own creation log) per test."""
+
+    class FakeSandbox:
+        created: list = []
+
+        def __init__(self):
+            self.id = f"fake-sandbox-{len(type(self).created)}"
+            self.state = "RUNNING"
+            self.closed = False
+            self.fail_next_close = False
+            type(self).created.append(self)
+
+        @classmethod
+        def create(cls, **kwargs):
+            return cls()
+
+        def exec(self, *argv, **kwargs):
+            if argv and "tail" in argv[-1]:
+                return _FakeExecResult(stdout_text="FAKE SERVER LOG")
+            return _FakeExecResult()
+
+        def expose_port(self, port, ttl=None):
+            # Nothing listens on port 9 ("discard"), so connections fail fast.
+            return SimpleNamespace(url="http://127.0.0.1:9")
+
+        def refresh(self):
+            pass
+
+        def close_if_open(self):
+            if self.fail_next_close:
+                self.fail_next_close = False
+                msg = "simulated termination failure"
+                raise RuntimeError(msg)
+            self.closed = True
+
+    return FakeSandbox
+
+
+@pytest.fixture
+def fake_sandbox_class(monkeypatch):
+    cls = _make_fake_sandbox_class()
+    monkeypatch.setattr("swerex.deployment.tenki.Sandbox", cls)
+    return cls
+
+
+@pytest.fixture
+def patched_wait(monkeypatch):
+    """Skip the readiness probe (there is no real server to connect to)."""
+
+    async def _noop(self, timeout):
+        return None
+
+    monkeypatch.setattr(TenkiDeployment, "_wait_until_alive", _noop)
+
+
+def _make_deployment(**kwargs) -> TenkiDeployment:
+    config = dict(project_id="proj-test", api_key="tk_test", runtime_retries=0, runtime_timeout=0.2)
+    config.update(kwargs)
+    return TenkiDeployment(**config)
+
+
+async def test_tenki_start_twice_raises_and_does_not_leak(fake_sandbox_class, patched_wait):
+    d = _make_deployment()
+    await d.start()
+    with pytest.raises(RuntimeError, match="already started"):
+        await d.start()
+    assert len(fake_sandbox_class.created) == 1
+    await d.stop()
+    assert fake_sandbox_class.created[0].closed
+
+
+async def test_tenki_startup_failure_terminates_sandbox_and_surfaces_log(fake_sandbox_class):
+    d = _make_deployment(startup_timeout=0.3)
+    with pytest.raises(RuntimeError, match="FAKE SERVER LOG"):
+        await d.start()
+    assert fake_sandbox_class.created[0].closed
+    with pytest.raises(RuntimeError):
+        await d.is_alive()
+
+
+async def test_tenki_stop_termination_failure_is_retryable(fake_sandbox_class, patched_wait):
+    d = _make_deployment()
+    await d.start()
+    sandbox = fake_sandbox_class.created[0]
+    sandbox.fail_next_close = True
+    with pytest.raises(RuntimeError, match="simulated termination failure"):
+        await d.stop()
+    assert not sandbox.closed
+    # The handle is kept, so stop() can be retried
+    await d.stop()
+    assert sandbox.closed
+
+
+async def test_tenki_stop_terminates_sandbox_when_runtime_close_cancelled(fake_sandbox_class, patched_wait):
+    d = _make_deployment()
+    await d.start()
+
+    class CancellingRuntime:
+        async def close(self):
+            raise asyncio.CancelledError
+
+    d._runtime = CancellingRuntime()
+    with pytest.raises(asyncio.CancelledError):
+        await d.stop()
+    assert fake_sandbox_class.created[0].closed
 
 
 @pytest.mark.cloud

--- a/tests/test_tenki_deployment.py
+++ b/tests/test_tenki_deployment.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+
+from swerex.deployment.tenki import TenkiDeployment
+from swerex.runtime.abstract import Command
+
+
+@pytest.mark.cloud
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not (os.getenv("TENKI_AUTH_TOKEN") or os.getenv("TENKI_API_KEY")),
+    reason="Tenki credentials not set (TENKI_AUTH_TOKEN or TENKI_API_KEY)",
+)
+async def test_tenki_deployment():
+    d = TenkiDeployment(startup_timeout=60 * 10)
+    with pytest.raises(RuntimeError):
+        await d.is_alive()
+    await d.start()
+    assert await d.is_alive()
+    response = await d.runtime.execute(Command(command="echo 'hello world'", shell=True))
+    assert response.exit_code == 0
+    assert "hello world" in response.stdout
+    await d.stop()


### PR DESCRIPTION
Supersedes #294 (closed before review; this version went through a full review pass on my fork first: lacdonlang/SWE-ReX#1).

## Summary

Adds a new deployment backend for [Tenki Sandbox](https://tenki.cloud), which provides disposable Linux microVMs for AI agents. It follows the same pattern as the existing `DaytonaDeployment`/`ModalDeployment`:

- `TenkiDeployment` (`src/swerex/deployment/tenki.py`) starts the SWE-ReX server inside a Tenki sandbox and connects to it through Tenki's port-exposure preview URL with a per-deployment auth token.
- `TenkiDeploymentConfig` with the usual knobs (`image`/`snapshot_id`, `cpu_cores`/`memory_mb`/`disk_size_gb`, `startup_timeout`/`runtime_timeout`/`container_timeout`, plus a `sandbox_kwargs` passthrough to `tenki_sandbox.Sandbox.create`).
- New optional dependency: `pip install 'swe-rex[tenki]'` (`tenki-sandbox >= 0.4.0`, added to the `dev` extra as well).
- Docs: installation, usage tutorial section, and API reference page.

## Changes to shared code (called out explicitly)

Two changes reach beyond the new backend; both keep existing behavior unchanged by default:

1. **`RemoteRuntimeConfig.num_retries` (default `0` — no change for existing backends).** A 5-minute probe against the Tenki preview gateway showed ~1% transient request failures, which would kill long agent runs, so the Tenki deployment defaults to 3 retries. Only transient network errors and gateway `502/503/504` responses are retried: the HTTP round-trip happens inside the retry scope and response interpretation outside it, so a server-side error can never be caught by the retry handler.
2. **Server-side `X-Request-ID` idempotency hardened.** The previous single-slot response cache could double-execute a request when a duplicate arrived while the original was still running, or when interleaved traffic evicted the slot. `ResponseManager` now deduplicates per ID: completed responses go into a bounded LRU cache and in-flight requests are tracked so a concurrent duplicate waits for the original instead of re-executing it. This is an improvement for any client that sends request IDs, independent of Tenki.

## Lifecycle safety

- `start()` raises if the deployment is already started (no leaked sandbox), and tears the sandbox down on any startup failure including cancellation. If the server doesn't come up in time, the error includes the tail of `/tmp/swerex.log` from the sandbox.
- `stop()` terminates the sandbox even if closing the runtime is cancelled; termination failures propagate and keep the handle so `stop()` can be retried.
- The sandbox is created with `max_duration=container_timeout` as a cost kill switch.
- If the image does not ship `swerex-remote`, the deployment falls back to installing it with pipx (via passwordless `sudo` when running as the default non-root sandbox user).

## Usage

```python
from swerex.deployment.tenki import TenkiDeployment

deployment = TenkiDeployment()  # reads TENKI_API_KEY from the environment
await deployment.start()
runtime = deployment.runtime  # a regular RemoteRuntime
...
await deployment.stop()
```

Credentials resolve the same way as in the Tenki SDK (`api_key` config field, falling back to `TENKI_AUTH_TOKEN`/`TENKI_API_KEY`). If the API key has access to exactly one project, the project is resolved automatically; otherwise `project_id` must be set.

## Testing

- Server idempotency tests (no credentials needed, run in CI against the real uvicorn test server): sequential replay served from cache, concurrent same-ID requests execute once, interleaved requests don't evict cached responses.
- Mocked `TenkiDeployment` lifecycle tests (no credentials needed): double-start guard, startup-failure cleanup + log surfacing, retryable `stop()`, cancellation-safe termination.
- `tests/test_get_deployment.py::test_get_tenki_deployment` (unit).
- `tests/test_tenki_deployment.py::test_tenki_deployment` (marked `cloud`/`slow`, skipped unless `TENKI_API_KEY`/`TENKI_AUTH_TOKEN` is set): full lifecycle against the real service, passes in ~30 s.
- Realistic user-workflow scenario against the live service, 11/11 checks: one-off `execute`, bash session state persistence, interactive python REPL via `expect`, non-zero exit codes, `write_file`/`read_file`/`upload`, real `git clone` + inspection.
- `pre-commit` (typos, ruff, ruff-format) passes on all changed files.