### PR TITLE
Fix: RemoteDeployment.is_alive accepts the timeout kwarg

### DIFF
--- a/src/swerex/deployment/remote.py
+++ b/src/swerex/deployment/remote.py
@@ -47,14 +47,14 @@ class RemoteDeployment(AbstractDeployment):
             raise DeploymentNotStartedError()
         return self._runtime
 
-    async def is_alive(self) -> IsAliveResponse:
+    async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
         """Checks if the runtime is alive. The return value can be
         tested with bool().
 
         Raises:
             DeploymentNotStartedError: If the deployment was not started.
         """
-        return await self.runtime.is_alive()
+        return await self.runtime.is_alive(timeout=timeout)
 
     async def start(self):
         """Starts the runtime."""

--- a/tests/test_remote_deployment.py
+++ b/tests/test_remote_deployment.py
@@ -13,4 +13,8 @@ async def test_remote_deployment(remote_server):
         await d.is_alive()
     await d.start()
     assert await d.is_alive()
+    # `timeout` is part of the AbstractDeployment interface and every other
+    # deployment accepts it; RemoteDeployment used to omit it, so callers
+    # written against the interface hit a TypeError here.
+    assert await d.is_alive(timeout=10)
     await d.stop()


### PR DESCRIPTION
`AbstractDeployment.is_alive` declares `*, timeout: float | None = None`, and every deployment implements it -- daytona, local, docker, fargate, dummy and modal all take the kwarg. `RemoteDeployment` was the sole exception: it overrode `is_alive` without the parameter and dropped the timeout when delegating to `RemoteRuntime.is_alive`, which does accept one.

Any caller written against the `AbstractDeployment` interface therefore breaks on this one deployment:

    TypeError: RemoteDeployment.is_alive() got an unexpected keyword argument 'timeout'

SWE-agent hits exactly this. `Agent.attempt_autosubmission_after_error` calls `self._env.deployment.is_alive(timeout=10)`, so on a remote deployment the recovery path that salvages a partial patch raises instead, and every recoverable task error becomes a total loss of that task's work. The docker path is unaffected, which is why this has gone unnoticed.

Pass the timeout through to the runtime, matching `LocalDeployment`.

The regression test asserts `is_alive(timeout=...)` on a started deployment; it fails with the above TypeError without this change.