### PR TITLE
Retry transport-level request failures

### DIFF
--- a/src/swerex/runtime/config.py
+++ b/src/swerex/runtime/config.py
@@ -28,6 +28,12 @@ class RemoteRuntimeConfig(BaseModel):
     """The port to connect to."""
     timeout: float = 0.15
     """The timeout for the runtime."""
+    num_retries: int = 3
+    """How many times to retry a request that failed with a transport-level error.
+
+    Retries reuse the request's `X-Request-ID`, so the server returns the original
+    response instead of executing the action a second time. Set to 0 to disable.
+    """
 
     type: Literal["remote"] = "remote"
     """Discriminator for (de)serialization/CLI. Do not change."""

--- a/src/swerex/runtime/remote.py
+++ b/src/swerex/runtime/remote.py
@@ -162,8 +162,19 @@ class RemoteRuntime(AbstractRuntime):
     async def wait_until_alive(self, *, timeout: float = 60.0):
         return await _wait_until_alive(self.is_alive, timeout=timeout)
 
-    async def _request(self, endpoint: str, payload: BaseModel | None, output_class: Any, num_retries: int = 0):
-        """Small helper to make requests to the server and handle errors and output."""
+    async def _request(
+        self, endpoint: str, payload: BaseModel | None, output_class: Any, num_retries: int | None = None
+    ):
+        """Small helper to make requests to the server and handle errors and output.
+
+        Transport-level failures are retried `num_retries` times (defaulting to
+        the runtime's `num_retries` config). Every attempt sends the same
+        `X-Request-ID`, so a retry of a request the server already ran -- or is
+        still running -- gets the original response back rather than executing
+        the action twice.
+        """
+        if num_retries is None:
+            num_retries = self._config.num_retries
         request_url = f"{self._api_url}/{endpoint}"
         request_id = str(uuid.uuid4())
         headers = self._headers.copy()

--- a/src/swerex/server.py
+++ b/src/swerex/server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import asyncio
 import shutil
 import tempfile
 import traceback
@@ -44,17 +45,47 @@ class ResponseManager:
     This stores the response of the last request, and is used in retries to return
     already executed requests.
 
+    A request is registered as in-flight *before* it is executed, so a retry that
+    arrives while the original is still running waits for that original instead of
+    starting a second, concurrent execution. Without this, a client retrying after
+    a dropped connection can run the same `run_in_session` action twice, and the
+    two commands interleave on a single shell.
+
     Note that in the case of multiple concurrent clients, idempotency isn't guaranteed.
     """
 
     def __init__(self):
         self.last_processed_request_id = None
         self.last_processed_response = None
+        # Keyed by request id rather than a single slot: two different requests
+        # in flight at once would otherwise overwrite each other's entry, and
+        # the first one's waiter would never be woken.
+        self._in_flight: dict[str, asyncio.Event] = {}
 
     def get_response(self, request_id):
         if request_id == self.last_processed_request_id:
             return self.last_processed_response
         return None
+
+    def mark_in_flight(self, request_id):
+        self._in_flight[request_id] = asyncio.Event()
+
+    def clear_in_flight(self, request_id):
+        event = self._in_flight.pop(request_id, None)
+        if event is not None:
+            event.set()
+
+    async def wait_for_in_flight(self, request_id):
+        """Await the in-flight request with this id and return its response.
+
+        Returns None if it is not in flight, or if it finished without recording
+        a response (it raised) -- in which case the caller should execute it.
+        """
+        event = self._in_flight.get(request_id)
+        if event is None:
+            return None
+        await event.wait()
+        return self.get_response(request_id)
 
     def set_response(self, request_id, response):
         self.last_processed_request_id = request_id
@@ -82,24 +113,35 @@ async def handle_request_id(request: Request, call_next):
         response = response_manager.get_response(request_id)
         if response:
             return response
+        # A retry that arrived while the original is still executing: wait for it
+        # rather than running the same action a second time.
+        response = await response_manager.wait_for_in_flight(request_id)
+        if response:
+            return response
+        response_manager.mark_in_flight(request_id)
 
-    response = await call_next(request)
+    try:
+        response = await call_next(request)
 
-    body_content = b""
-    async for chunk in response.body_iterator:
-        body_content += chunk
+        body_content = b""
+        async for chunk in response.body_iterator:
+            body_content += chunk
 
-    new_response = Response(
-        content=body_content,
-        status_code=response.status_code,
-        headers=dict(response.headers),
-        media_type=response.media_type,
-    )
+        new_response = Response(
+            content=body_content,
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            media_type=response.media_type,
+        )
 
-    if request_id:
-        response_manager.set_response(request_id, new_response)
+        if request_id:
+            response_manager.set_response(request_id, new_response)
 
-    return new_response
+        return new_response
+    finally:
+        # Must run even if the handler raised or was cancelled, or a waiting
+        # retry would block until its own client timeout.
+        response_manager.clear_in_flight(request_id)
 
 
 @app.exception_handler(Exception)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -93,9 +93,12 @@ def test_concurrent_distinct_request_ids_do_not_clobber_each_other(remote_server
     url = f"http://127.0.0.1:{remote_server.port}/execute"
 
     def post(rid, cmd):
-        return requests.post(url, json={"command": cmd, "shell": True},
-                             headers={**remote_server.headers, "X-Request-ID": rid},
-                             timeout=30)
+        return requests.post(
+            url,
+            json={"command": cmd, "shell": True},
+            headers={**remote_server.headers, "X-Request-ID": rid},
+            timeout=30,
+        )
 
     a, b = str(uuid.uuid4()), str(uuid.uuid4())
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
@@ -103,7 +106,7 @@ def test_concurrent_distinct_request_ids_do_not_clobber_each_other(remote_server
         time.sleep(0.3)
         fb = pool.submit(post, b, "echo other")
         time.sleep(0.3)
-        fa_retry = pool.submit(post, a, "sleep 2; echo $RANDOM")   # retry of A
+        fa_retry = pool.submit(post, a, "sleep 2; echo $RANDOM")  # retry of A
         ra, rb, ra2 = fa.result(), fb.result(), fa_retry.result()
 
     assert rb.json()["stdout"].strip() == "other"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,5 @@
+import time
+
 import requests
 
 from tests.conftest import RemoteServer
@@ -33,3 +35,77 @@ def test_unauthenticated_request(remote_server: RemoteServer):
     ]:
         response = requests.get(f"http://127.0.0.1:{remote_server.port}/{endpoint}")
         assert response.status_code == 403
+
+
+def test_duplicate_request_id_while_in_flight_is_not_executed_twice(remote_server: RemoteServer):
+    """A retry that arrives before the original finishes must wait for it.
+
+    The client retries transport-level failures reusing the same X-Request-ID.
+    The response cache alone only covers requests that already *finished*; a
+    retry sent while the original is still running used to slip past it and
+    execute the action a second time. `$RANDOM` makes that observable without
+    depending on timing: one execution means both callers see the same value.
+    """
+    import concurrent.futures
+    import uuid
+
+    request_id = str(uuid.uuid4())
+    payload = {"command": "sleep 2; echo $RANDOM", "shell": True}
+    headers = {**remote_server.headers, "X-Request-ID": request_id}
+    url = f"http://127.0.0.1:{remote_server.port}/execute"
+
+    def post():
+        return requests.post(url, json=payload, headers=headers, timeout=30)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(post)
+        time.sleep(0.5)  # ensure the second lands while the first is still running
+        second = pool.submit(post)
+        r1, r2 = first.result(), second.result()
+
+    assert r1.status_code == 200, r1.text
+    assert r2.status_code == 200, r2.text
+    assert r1.json()["stdout"] == r2.json()["stdout"]
+
+
+def test_duplicate_request_id_after_completion_is_served_from_cache(remote_server: RemoteServer):
+    import uuid
+
+    request_id = str(uuid.uuid4())
+    payload = {"command": "echo $RANDOM", "shell": True}
+    headers = {**remote_server.headers, "X-Request-ID": request_id}
+    url = f"http://127.0.0.1:{remote_server.port}/execute"
+
+    r1 = requests.post(url, json=payload, headers=headers, timeout=30)
+    r2 = requests.post(url, json=payload, headers=headers, timeout=30)
+    assert r1.json()["stdout"] == r2.json()["stdout"]
+
+
+def test_concurrent_distinct_request_ids_do_not_clobber_each_other(remote_server: RemoteServer):
+    """Two different requests in flight at once must each be tracked.
+
+    A single in-flight slot would let the second overwrite the first, so the
+    first's waiter is never woken and blocks until its own client timeout.
+    """
+    import concurrent.futures
+    import uuid
+
+    url = f"http://127.0.0.1:{remote_server.port}/execute"
+
+    def post(rid, cmd):
+        return requests.post(url, json={"command": cmd, "shell": True},
+                             headers={**remote_server.headers, "X-Request-ID": rid},
+                             timeout=30)
+
+    a, b = str(uuid.uuid4()), str(uuid.uuid4())
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+        fa = pool.submit(post, a, "sleep 2; echo $RANDOM")
+        time.sleep(0.3)
+        fb = pool.submit(post, b, "echo other")
+        time.sleep(0.3)
+        fa_retry = pool.submit(post, a, "sleep 2; echo $RANDOM")   # retry of A
+        ra, rb, ra2 = fa.result(), fb.result(), fa_retry.result()
+
+    assert rb.json()["stdout"].strip() == "other"
+    # The retry of A must still be matched to A, not lost because B arrived.
+    assert ra.json()["stdout"] == ra2.json()["stdout"]


### PR DESCRIPTION
`RemoteRuntime._request` already has a retry loop with exponential backoff, and every request already carries an `X-Request-ID` the server treats as an idempotency key. But num_retries defaults to 0 and none of the seven callers overrides it, so the whole mechanism is unreachable: the first transport-level failure on any request is fatal.

That matters wherever the connection to the server is less reliable than the server itself -- a tunnel, a proxy, a load balancer with an idle timeout. A dropped connection mid-request kills the agent's whole trajectory, even though the runtime is still there and the request is safely replayable.

`num_retries` becomes a `RemoteRuntimeConfig` field defaulting to 3, and `_request` takes its default from it. Retries reuse the same request id, so a retry of a request the server already ran gets the original response back.

Enabling that alone would not be safe. `ResponseManager` recorded a response only after the handler returned, so a retry arriving while the original was still executing missed the cache and ran the action a second time -- for `run_in_session`, two commands interleaved on one shell. A request is now registered as in-flight before it runs, and a duplicate awaits the original instead of racing it. The registry is keyed by request id so two different concurrent requests cannot overwrite each other's entry and strand a waiter.

Tests cover the retry of a completed request, the retry of one still running, and two concurrent distinct ids.